### PR TITLE
Fix release workflow to publish when any platform build succeeds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,6 @@ jobs:
     name: Build release assets (linux)
     needs: [validate, tag]
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +113,6 @@ jobs:
     name: Build release assets (macos)
     needs: [validate, tag]
     runs-on: macos-latest
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4
@@ -158,7 +156,6 @@ jobs:
     name: Build release assets (windows)
     needs: [validate, tag]
     runs-on: windows-latest
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,7 @@ This repository uses a single automated GitHub Actions release workflow (`.githu
 - Python wheel (`.whl`)
 
 ## Failure handling
-- CI failures stop the release.
 - Release notes validation failures stop the release before tagging.
-- PyPI publish can be disabled during dry runs (`publish_to_pypi: false`).
+- A GitHub release is still published when at least one platform build succeeds; only successful platform artifacts are attached.
+- If all platform builds fail, the release job fails and nothing is published.
+- PyPI publish still requires the Linux build artifacts and can be disabled during dry runs (`publish_to_pypi: false`).


### PR DESCRIPTION
### **User description**
### Motivation
- Prevent a single-platform CI failure from blocking release delivery so initial releases can be published with available artifacts. 
- Remove masking behavior where `continue-on-error` hid real build failures and made job status unreliable. 
- Make release failure handling explicit so maintainers understand partial-success publishing and PyPI dependencies. 

### Description
- Removed `continue-on-error` from the `build_linux`, `build_macos`, and `build_windows` jobs in `.github/workflows/release.yml` so platform build failures are reported as failures. 
- Preserved the existing `github_release` guard that publishes a GitHub Release when at least one platform build succeeds and attaches only the artifacts produced by successful jobs. 
- Updated `RELEASING.md` to describe the new failure-handling behavior, including that a release is published when any platform succeeds, that all-platform failure blocks publishing, and that PyPI publishing still depends on Linux artifacts. 

### Testing
- Validated the modified workflow YAML by parsing `.github/workflows/release.yml` with `python` and `yaml.safe_load`, which succeeded (`yaml ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c452168883338bc63c251ce586af)


___

### **Description**
- Enhanced the release workflow to ensure that platform build failures are reported accurately.
- Updated documentation to reflect new failure handling behavior for releases.
- Clarified that a release is published when any platform succeeds, while all-platform failures block publishing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Update release workflow to handle build failures explicitly</code></dd></summary>
<hr>

.github/workflows/release.yml
<li>Removed <code>continue-on-error</code> from <code>build_linux</code>, <code>build_macos</code>, and <br><code>build_windows</code> jobs.<br> <li> Ensured platform build failures are reported as failures.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/43/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RELEASING.md</strong><dd><code>Clarify release process and failure handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RELEASING.md
<li>Updated failure handling section to clarify release behavior.<br> <li> Specified conditions under which a release is published.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/43/files#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785d">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

