### PR TITLE
Fix syntax error in desktop message audit when connector is missing

### DIFF
--- a/src/magnetar/tools/system_interaction.py
+++ b/src/magnetar/tools/system_interaction.py
@@ -185,13 +185,13 @@ class SystemInteractionModule:
         connector = self.desktop_connectors.get(app_name.lower())
         if connector is None:
             self.audit.record(
-        connector = self.desktop_connectors.get(app_name.lower())
-        if connector is None:
-            self._audit(
-                action="desktop_message_connector_missing",
-                target=app_name,
-                allowed=False,
-                reason="No connector registered for app",
+                AuditEvent(
+                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    action="desktop_message_connector_missing",
+                    target=app_name,
+                    allowed=False,
+                    reason="No connector registered for app",
+                )
             )
             return None
         return connector.send_message(channel=channel, message=message)


### PR DESCRIPTION
### **User description**
### Motivation
- Resolve a `SyntaxError` during import/test collection caused by a malformed audit call in `SystemInteractionModule.send_desktop_message` so the module can be imported and tests can run.

### Description
- Replace the broken/mismatched lines with a proper `self.audit.record(AuditEvent(...))` that logs a `desktop_message_connector_missing` event and retain the early `return None` when no connector is registered.

### Testing
- Ran `poetry run pytest --junitxml=pytest-report.xml -vv` which now proceeds but fails in this environment due to missing optional dependencies (`litellm`, `chromadb`), and ran `poetry run pytest tests/test_tools.py -vv` which passed all 13 tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c798ed9083339b6f3b60d950aba0)

## Summary by Sourcery

Bug Fixes:
- Correct the desktop message audit call to log a structured AuditEvent when no connector is registered, resolving an import-time syntax error.


___

### **Description**
- Resolved a `SyntaxError` during import/test collection in `SystemInteractionModule.send_desktop_message`.
- Updated the audit call to log a structured `AuditEvent` when no connector is registered.
- Ensured early return with `return None` is retained for unregistered connectors.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_interaction.py</strong><dd><code>Fix syntax error in desktop message audit call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/magnetar/tools/system_interaction.py
<li>Fixed a syntax error in the desktop message audit call.<br> <li> Replaced broken audit call with a structured <code>AuditEvent</code>.<br> <li> Maintained early return when no connector is registered.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/49/files#diff-6b6212cf4ec453306e3e1c327d0de9cdf84469e23df043b36c4909908dd513df">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

