### PR TITLE
Fix duplicate release assets in GitHub release workflows

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -130,7 +130,6 @@ jobs:
       - name: Collect release assets
         run: |
           mkdir -p release-assets
-          cp dist/* release-assets/
           cp dist/magnetar-macos release-assets/
 
       - name: Upload release asset bundle
@@ -172,7 +171,6 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path release-assets -Force | Out-Null
-          Copy-Item -Path dist\* -Destination release-assets -Force
           Copy-Item -Path dist\magnetar-windows.exe -Destination release-assets -Force
 
       - name: Upload release asset bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,6 @@ jobs:
       - name: Collect release assets
         run: |
           mkdir -p release-assets
-          cp dist/* release-assets/
           cp dist/magnetar-macos release-assets/
 
       - name: Upload release asset bundle
@@ -205,7 +204,6 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path release-assets -Force | Out-Null
-          Copy-Item -Path dist\* -Destination release-assets -Force
           Copy-Item -Path dist\magnetar-windows.exe -Destination release-assets -Force
 
       - name: Upload release asset bundle


### PR DESCRIPTION
### **User description**
### Motivation
- The GitHub release step was intermittently failing with `Not Found` because `softprops/action-gh-release` saw duplicate artifact filenames (`.tar.gz`/`.whl`) uploaded from multiple platform jobs. 
- The intent is to make Linux the single source for Python `dist/` artifacts while letting macOS and Windows only upload their platform binaries so each asset name is uploaded exactly once.

### Description
- Removed `cp dist/* release-assets/` from macOS asset collection in `.github/workflows/release.yml` and `.github/workflows/release-branch.yml`.
- Removed `Copy-Item -Path dist\* -Destination release-assets -Force` from Windows asset collection in both workflows.
- Preserved Linux job behavior to upload `dist/` as the single source of the `sdist`/`wheel`, while macOS/Windows continue to upload only `magnetar-macos` and `magnetar-windows.exe` respectively.
- Changes were committed with message `Fix release asset duplication across platform builds`.

### Testing
- Located and inspected workflow usage with `rg` to confirm the release steps and targets, which succeeded.
- Applied the workflow edits using `apply_patch` and validated the modifications with `git diff` and `nl -ba`, which confirmed the intended removals succeeded.
- Committed the changes with `git commit` and generated the PR body via the repository tooling, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d326cebc8333b5dfbd98b58c98e3)

## Summary by Sourcery

CI:
- Update release workflows so macOS and Windows jobs only upload their platform-specific binaries while Linux remains the sole source of Python dist/ artifacts.


___

### **Description**
- Enhanced GitHub release workflows to prevent duplicate asset uploads.
- Ensured Linux remains the sole source for Python `dist/` artifacts.
- macOS and Windows now only upload their respective platform binaries.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-branch.yml</strong><dd><code>Update release asset collection for platform-specific binaries</code></dd></summary>
<hr>

.github/workflows/release-branch.yml
<li>Removed copying of all artifacts from <code>dist/</code> for macOS.<br> <li> Removed copying of all artifacts from <code>dist/</code> for Windows.<br> <li> Preserved platform-specific binaries upload behavior.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/53/files#diff-296c473d3c4dc10830ece36833b6dc657be48e7769066fe8101c492efc78281b">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Update release asset collection for platform-specific binaries</code></dd></summary>
<hr>

.github/workflows/release.yml
<li>Removed copying of all artifacts from <code>dist/</code> for macOS.<br> <li> Removed copying of all artifacts from <code>dist/</code> for Windows.<br> <li> Preserved platform-specific binaries upload behavior.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/53/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

