### PR TITLE
Add expanded release packaging workflow for macOS (Intel/Apple Silicon), Windows x86, and Linux packages

### DIFF
--- a/.github/workflows/release-packaging.yml
+++ b/.github/workflows/release-packaging.yml
@@ -1,0 +1,355 @@
+name: Release Packaging Expansion
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semantic version without leading v (example: 0.2.0)"
+        required: true
+        type: string
+      release_notes:
+        description: "Extremely detailed release notes in markdown format"
+        required: true
+        type: string
+  push:
+    branches:
+      - release
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    name: Prepare packaging metadata
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      release_name: ${{ steps.meta.outputs.release_name }}
+      notes_file: ${{ steps.meta.outputs.notes_file }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release metadata
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+            RELEASE_NAME="Release v${VERSION}"
+            NOTES_FILE="RELEASE_NOTES_VALIDATED.md"
+          else
+            VERSION=$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))
+          print(data['tool']['poetry']['version'])
+          PY
+            )
+            RELEASE_NAME="Release v${VERSION} (${GITHUB_SHA::7})"
+            NOTES_FILE="RELEASE_NOTES_AUTOMATED.md"
+          fi
+
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "notes_file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
+
+      - name: Persist release notes (manual)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          cat > RELEASE_NOTES_VALIDATED.md <<'EOF'
+          ${{ github.event.inputs.release_notes }}
+          EOF
+
+      - name: Persist release notes (release branch)
+        if: github.event_name == 'push'
+        run: |
+          cat > RELEASE_NOTES_AUTOMATED.md <<EOF
+          ## Automated packaging release delivery from branch \`release\`
+
+          - Version: \`${{ steps.meta.outputs.version }}\`
+          - Commit: \`${GITHUB_SHA}\`
+          - Workflow run: \`${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\`
+
+          This release is generated automatically after a merge/push to \`release\`.
+          Assets include: macOS Intel + Apple Silicon, Linux DEB/RPM/AppImage/SNAP, and Windows x86.
+          EOF
+
+      - name: Validate release notes structure
+        if: github.event_name == 'workflow_dispatch'
+        run: python .github/scripts/validate_release_notes.py --file RELEASE_NOTES_VALIDATED.md --min-chars 1200
+
+      - name: Ensure tag exists
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists; skipping creation."
+          else
+            git tag "${TAG}" "${GITHUB_SHA}"
+            git push origin "${TAG}"
+          fi
+
+      - name: Upload release notes artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: expanded-release-notes
+          path: ${{ steps.meta.outputs.notes_file }}
+
+  build_macos:
+    name: Build macOS standalone binary (${{ matrix.target }})
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: intel
+            runner: macos-13
+            binary_name: magnetar-macos-intel
+          - target: apple-silicon
+            runner: macos-14
+            binary_name: magnetar-macos-apple-silicon
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller rich
+          pip install .
+
+      - name: Build standalone binary
+        run: >-
+          python -m PyInstaller
+          --onefile
+          --name ${{ matrix.binary_name }}
+          src/magnetar/cli.py
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-macos-${{ matrix.target }}
+          path: dist/${{ matrix.binary_name }}
+
+  build_windows_x86:
+    name: Build Windows x86 standalone binary
+    needs: prepare
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Setup Python (x86)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          architecture: x86
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller rich
+          pip install .
+
+      - name: Build standalone binary
+        run: >-
+          python -m PyInstaller
+          --onefile
+          --name magnetar-windows-x86
+          src/magnetar/cli.py
+
+      - name: Upload Windows x86 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-windows-x86
+          path: dist/magnetar-windows-x86.exe
+
+  build_linux_packages:
+    name: Build Linux package formats
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby ruby-dev rpm squashfs-tools desktop-file-utils
+          sudo gem install --no-document fpm
+          python -m pip install --upgrade pip
+          pip install pyinstaller rich
+          pip install .
+
+      - name: Build Linux standalone binary
+        run: >-
+          python -m PyInstaller
+          --onefile
+          --name magnetar-linux-x86_64
+          src/magnetar/cli.py
+
+      - name: Build DEB and RPM packages
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          mkdir -p package-root/usr/local/bin
+          install -m 0755 dist/magnetar-linux-x86_64 package-root/usr/local/bin/magnetar
+
+          fpm -s dir -t deb -n magnetar -v "$VERSION" --architecture amd64 \
+            --description "Magnetar CLI" --url "https://github.com/${GITHUB_REPOSITORY}" \
+            -C package-root usr/local/bin/magnetar
+
+          fpm -s dir -t rpm -n magnetar -v "$VERSION" --architecture x86_64 \
+            --description "Magnetar CLI" --url "https://github.com/${GITHUB_REPOSITORY}" \
+            -C package-root usr/local/bin/magnetar
+
+      - name: Build AppImage
+        run: |
+          mkdir -p AppDir/usr/bin AppDir/usr/share/applications
+          install -m 0755 dist/magnetar-linux-x86_64 AppDir/usr/bin/magnetar
+          cat > AppDir/usr/share/applications/magnetar.desktop <<'EOF'
+          [Desktop Entry]
+          Name=Magnetar
+          Exec=magnetar
+          Type=Application
+          Categories=Utility;
+          Terminal=true
+          EOF
+          cp AppDir/usr/share/applications/magnetar.desktop AppDir/magnetar.desktop
+
+          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
+          chmod +x appimagetool
+          ./appimagetool AppDir magnetar-${{ needs.prepare.outputs.version }}-x86_64.AppImage
+
+      - name: Prepare snapcraft definition
+        run: |
+          mkdir -p snap
+          cat > snap/snapcraft.yaml <<'EOF'
+          name: magnetar
+          base: core22
+          version: '${{ needs.prepare.outputs.version }}'
+          summary: Magnetar CLI
+          description: |
+            Magnetar command line interface packaged as a snap.
+          grade: stable
+          confinement: strict
+
+          apps:
+            magnetar:
+              command: bin/magnetar
+
+          parts:
+            magnetar:
+              plugin: dump
+              source: dist
+              organize:
+                magnetar-linux-x86_64: bin/magnetar
+          EOF
+
+      - name: Build SNAP package
+        uses: snapcore/action-build@v1
+        with:
+          snapcraft-args: --destructive-mode
+
+      - name: Collect Linux packaging artifacts
+        run: |
+          mkdir -p release-assets
+          cp *.deb release-assets/
+          cp *.rpm release-assets/
+          cp *.AppImage release-assets/
+          cp *.snap release-assets/
+          cp dist/magnetar-linux-x86_64 release-assets/
+
+      - name: Upload Linux packaging artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-linux-packaging
+          path: release-assets/*
+
+  github_release:
+    name: Publish GitHub release with expanded artifacts
+    if: >-
+      always() &&
+      (needs.build_macos.result == 'success' || needs.build_windows_x86.result == 'success' || needs.build_linux_packages.result == 'success')
+    needs: [prepare, build_macos, build_windows_x86, build_linux_packages]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release notes
+        uses: actions/download-artifact@v4
+        with:
+          name: expanded-release-notes
+          path: release-notes
+
+      - name: Download macOS Intel artifact
+        if: needs.build_macos.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets-macos-intel
+          path: release-assets/macos-intel
+
+      - name: Download macOS Apple Silicon artifact
+        if: needs.build_macos.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets-macos-apple-silicon
+          path: release-assets/macos-apple-silicon
+
+      - name: Download Windows x86 artifact
+        if: needs.build_windows_x86.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets-windows-x86
+          path: release-assets/windows-x86
+
+      - name: Download Linux packaging artifacts
+        if: needs.build_linux_packages.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets-linux-packaging
+          path: release-assets/linux-packaging
+
+      - name: Ensure at least one release artifact exists
+        run: |
+          if ! find release-assets -type f | grep -q .; then
+            echo "No expanded release artifacts were produced."
+            exit 1
+          fi
+
+      - name: Create or update GitHub release with expanded artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          name: ${{ needs.prepare.outputs.release_name }}
+          body_path: release-notes/${{ needs.prepare.outputs.notes_file }}
+          overwrite_files: true
+          files: |
+            release-assets/macos-intel/*
+            release-assets/macos-apple-silicon/*
+            release-assets/windows-x86/*
+            release-assets/linux-packaging/*


### PR DESCRIPTION
### **User description**
### Motivation
- Provide additional release pipelines that do not modify existing workflows and deliver artifacts from both manual dispatch and the `release` branch.
- Produce platform-specific release artifacts for macOS Intel, macOS Apple Silicon, Windows x86, and multiple Linux packaging formats (`.deb`, `.rpm`, `.AppImage`, `.snap`).

### Description
- Add a new GitHub Actions workflow at `.github/workflows/release-packaging.yml` that triggers on `workflow_dispatch` and `push` to the `release` branch and prepares release metadata and notes.
- Add a macOS build matrix job that produces standalone binaries for Intel (`macos-13`) and Apple Silicon (`macos-14`) using `PyInstaller` and uploads artifacts per-arch.
- Add a Windows x86 job that sets `architecture: x86`, runs `PyInstaller` to produce a `magnetar-windows-x86.exe`, and uploads the artifact.
- Add a Linux packaging job that builds a Linux standalone binary and packages it into `.deb`, `.rpm`, `.AppImage`, and `.snap` using `fpm`, `appimagetool`, and `snapcraft` (via `snapcore/action-build@v1`), then uploads the packaging artifacts; finally, a release publisher job collects all artifacts and creates/updates the GitHub release.

### Testing
- Validated the new workflow YAML syntax by loading it with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-packaging.yml')"`, which completed successfully.
- Ensured workflow content consistency by running a local YAML parse and basic inspections of the generated file paths and artifact names, with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d5df1f5083338e5bc1b9d84d49f8)

## Summary by Sourcery

Introduce a dedicated GitHub Actions workflow to build and publish expanded cross-platform release artifacts from manual dispatches and the release branch.

Build:
- Add a release-packaging workflow that prepares release metadata, manages tags, and orchestrates multi-platform packaging for releases.

CI:
- Add GitHub Actions jobs to build macOS (Intel and Apple Silicon), Windows x86, and Linux binaries and packages, then aggregate them into a GitHub release with validated release notes.


___

### **Description**
- Added a comprehensive GitHub Actions workflow to facilitate cross-platform release packaging.
- Supports manual dispatch and automated triggers on the `release` branch.
- Builds standalone binaries for macOS (Intel and Apple Silicon), Windows x86, and various Linux package formats.
- Implements versioning and structured release notes management.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-packaging.yml</strong><dd><code>Expanded Release Packaging Workflow for Multiple Platforms</code></dd></summary>
<hr>

.github/workflows/release-packaging.yml
<li>Introduced a new GitHub Actions workflow for expanded release <br>packaging.<br> <li> Added jobs for building macOS, Windows, and Linux binaries and <br>packages.<br> <li> Implemented versioning and release notes handling for manual and <br>automated triggers.<br> <li> Enhanced artifact management for cross-platform releases.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/54/files#diff-19ecbe3ea7a31867299a2cc936f56bebbc1abfcb43b7267ac23e78bcf895a1be">+355/-0</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

