### PR TITLE
Fix AppImage packaging on GitHub runners without FUSE

### DIFF
--- a/.github/workflows/release-packaging.yml
+++ b/.github/workflows/release-packaging.yml
@@ -200,7 +200,13 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y ruby ruby-dev rpm squashfs-tools desktop-file-utils
+          if apt-cache show libfuse2 >/dev/null 2>&1; then
+            FUSE_PACKAGE="libfuse2"
+          else
+            FUSE_PACKAGE="libfuse2t64"
+          fi
+
+          sudo apt-get install -y ruby ruby-dev rpm squashfs-tools desktop-file-utils "$FUSE_PACKAGE"
           sudo gem install --no-document fpm
           python -m pip install --upgrade pip
           pip install pyinstaller rich
@@ -244,7 +250,7 @@ jobs:
 
           wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
           chmod +x appimagetool
-          ./appimagetool AppDir magnetar-${{ needs.prepare.outputs.version }}-x86_64.AppImage
+          APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool AppDir magnetar-${{ needs.prepare.outputs.version }}-x86_64.AppImage
 
       - name: Prepare snapcraft definition
         run: |


### PR DESCRIPTION
### **User description**
### Motivation
- CI runs produced `dlopen(): error loading libfuse.so.2` when building AppImages because the FUSE userspace library was not available on some GitHub runner images. 
- The AppImage tooling can be blocked in restricted environments where kernel FUSE mounts are unavailable, so a fallback is needed to produce artifacts in CI.

### Description
- Add an `apt-cache` check to detect and install the available FUSE compatibility package by choosing `libfuse2` or falling back to `libfuse2t64` before building Linux packages. 
- Ensure the selected FUSE package is installed alongside existing build dependencies (`ruby`, `rpm`, `squashfs-tools`, `desktop-file-utils`).
- Change the `appimagetool` invocation to run with `APPIMAGE_EXTRACT_AND_RUN=1` so the tool can operate in environments where FUSE mounting is restricted.

### Testing
- Ran `git diff --check` to validate patch formatting, which completed successfully. 
- Ran `git status --short` to confirm the workflow file was updated and staged changes are present, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d84a4294833391867f749b6cc778)


___

### **Description**
- Enhanced the AppImage build process to handle environments without FUSE.
- Added a check to install the appropriate FUSE package based on availability.
- Changed the invocation of `appimagetool` to support restricted environments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-packaging.yml</strong><dd><code>Improve FUSE package installation for AppImage builds</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-packaging.yml
<li>Added logic to check for available FUSE packages.<br> <li> Installed <code>libfuse2</code> or <code>libfuse2t64</code> based on availability.<br> <li> Modified <code>appimagetool</code> invocation to run with <br><code>APPIMAGE_EXTRACT_AND_RUN=1</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/55/files#diff-19ecbe3ea7a31867299a2cc936f56bebbc1abfcb43b7267ac23e78bcf895a1be">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system compatibility by enhancing FUSE library selection logic for better Linux distribution support.
  * Updated AppImage packaging configuration to ensure reliable extraction and execution across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->