### PR TITLE
Clear ChromaDB SharedSystemClient cache in ChromaMemoryStore.close()

### DIFF
--- a/src/magnetar/memory/chroma.py
+++ b/src/magnetar/memory/chroma.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import List, Dict, Any, Optional
 import chromadb
+from chromadb.api.client import SharedSystemClient
 from magnetar.memory.store import MemoryStore, MemoryResult
 
 class ChromaMemoryStore(MemoryStore):
@@ -59,3 +60,13 @@ class ChromaMemoryStore(MemoryStore):
             return MemoryResult(success=True)
         except Exception as e:
             return MemoryResult(success=False, error=str(e))
+
+    def close(self) -> None:
+        """Release resources held by the Chroma client/system cache."""
+        try:
+            SharedSystemClient.clear_system_cache()
+        except Exception:
+            pass
+
+        self.client = None
+        self.collection = None


### PR DESCRIPTION
### **User description**
### Motivation
- Prevent ChromaDB's process-wide cached `System` instances from keeping SQLite file handles open and causing Windows `PermissionError` when removing persistent directories by evicting the cached system during teardown.

### Description
- Import `SharedSystemClient` from `chromadb.api.client` and add `ChromaMemoryStore.close()` which calls `SharedSystemClient.clear_system_cache()` (guarded with `try/except`) and then sets `self.client` and `self.collection` to `None` to allow resource cleanup.

### Testing
- Ran `python -m compileall src/magnetar/memory/chroma.py`, which succeeded.
- Ran `pytest -q`, which failed during collection due to missing optional dependencies `litellm` and `chromadb` in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d9560b548333a521296197e0f373)

## Summary by Sourcery

Enhancements:
- Introduce a close() method on ChromaMemoryStore that clears the ChromaDB SharedSystemClient cache and drops client/collection references to aid resource cleanup.


___

### **Description**
- Introduced a `close()` method in `ChromaMemoryStore` to clear the `SharedSystemClient` cache.
- This change prevents potential `PermissionError` on Windows by releasing resources during teardown.
- The method includes error handling to ensure stability during cache clearing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chroma.py</strong><dd><code>Implement close method for resource cleanup in ChromaMemoryStore</code></dd></summary>
<hr>

src/magnetar/memory/chroma.py
<li>Added a <code>close()</code> method to <code>ChromaMemoryStore</code>.<br> <li> The method clears the <code>SharedSystemClient</code> cache.<br> <li> Sets <code>self.client</code> and <code>self.collection</code> to <code>None</code> for resource cleanup.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/56/files#diff-d6099461e241325bf75afd2ea815addc89d9ceebde250ff07aff2dddbf1e4e6d">+11/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

