### PR TITLE
Split release packaging workflow into OS-specific files

### DIFF
--- a/.github/workflows/release-packaging-linux.yml
+++ b/.github/workflows/release-packaging-linux.yml
@@ -1,0 +1,127 @@
+name: Release Packaging Linux
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Git tag to checkout for release packaging"
+        required: true
+        type: string
+      version:
+        description: "Release semantic version"
+        required: true
+        type: string
+
+jobs:
+  build_linux_packages:
+    name: Build Linux package formats
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          if apt-cache show libfuse2 >/dev/null 2>&1; then
+            FUSE_PACKAGE="libfuse2"
+          else
+            FUSE_PACKAGE="libfuse2t64"
+          fi
+
+          sudo apt-get install -y ruby ruby-dev rpm squashfs-tools desktop-file-utils "$FUSE_PACKAGE"
+          sudo gem install --no-document fpm
+          python -m pip install --upgrade pip
+          pip install pyinstaller rich
+          pip install .
+
+      - name: Build Linux standalone binary
+        run: >-
+          python -m PyInstaller
+          --onefile
+          --name magnetar-linux-x86_64
+          src/magnetar/cli.py
+
+      - name: Build DEB and RPM packages
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          mkdir -p package-root/usr/local/bin
+          install -m 0755 dist/magnetar-linux-x86_64 package-root/usr/local/bin/magnetar
+
+          fpm -s dir -t deb -n magnetar -v "$VERSION" --architecture amd64 \
+            --description "Magnetar CLI" --url "https://github.com/${GITHUB_REPOSITORY}" \
+            -C package-root usr/local/bin/magnetar
+
+          fpm -s dir -t rpm -n magnetar -v "$VERSION" --architecture x86_64 \
+            --description "Magnetar CLI" --url "https://github.com/${GITHUB_REPOSITORY}" \
+            -C package-root usr/local/bin/magnetar
+
+      - name: Build AppImage
+        run: |
+          mkdir -p AppDir/usr/bin AppDir/usr/share/applications
+          install -m 0755 dist/magnetar-linux-x86_64 AppDir/usr/bin/magnetar
+          cat > AppDir/usr/share/applications/magnetar.desktop <<'EOF'
+          [Desktop Entry]
+          Name=Magnetar
+          Exec=magnetar
+          Type=Application
+          Categories=Utility;
+          Terminal=true
+          EOF
+          cp AppDir/usr/share/applications/magnetar.desktop AppDir/magnetar.desktop
+
+          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
+          chmod +x appimagetool
+          APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool AppDir magnetar-${{ inputs.version }}-x86_64.AppImage
+
+      - name: Prepare snapcraft definition
+        run: |
+          mkdir -p snap
+          cat > snap/snapcraft.yaml <<'EOF'
+          name: magnetar
+          base: core22
+          version: '${{ inputs.version }}'
+          summary: Magnetar CLI
+          description: |
+            Magnetar command line interface packaged as a snap.
+          grade: stable
+          confinement: strict
+
+          apps:
+            magnetar:
+              command: bin/magnetar
+
+          parts:
+            magnetar:
+              plugin: dump
+              source: dist
+              organize:
+                magnetar-linux-x86_64: bin/magnetar
+          EOF
+
+      - name: Build SNAP package
+        uses: snapcore/action-build@v1
+        with:
+          snapcraft-args: --destructive-mode
+
+      - name: Collect Linux packaging artifacts
+        run: |
+          mkdir -p release-assets
+          cp *.deb release-assets/
+          cp *.rpm release-assets/
+          cp *.AppImage release-assets/
+          cp *.snap release-assets/
+          cp dist/magnetar-linux-x86_64 release-assets/
+
+      - name: Upload Linux packaging artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-linux-packaging
+          path: release-assets/*

--- a/.github/workflows/release-packaging-macos.yml
+++ b/.github/workflows/release-packaging-macos.yml
@@ -1,0 +1,52 @@
+name: Release Packaging macOS
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Git tag to checkout for release packaging"
+        required: true
+        type: string
+
+jobs:
+  build_macos:
+    name: Build macOS standalone binary (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: intel
+            runner: macos-13
+            binary_name: magnetar-macos-intel
+          - target: apple-silicon
+            runner: macos-14
+            binary_name: magnetar-macos-apple-silicon
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller rich
+          pip install .
+
+      - name: Build standalone binary
+        run: >-
+          python -m PyInstaller
+          --onefile
+          --name ${{ matrix.binary_name }}
+          src/magnetar/cli.py
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-macos-${{ matrix.target }}
+          path: dist/${{ matrix.binary_name }}

--- a/.github/workflows/release-packaging-windows-x86.yml
+++ b/.github/workflows/release-packaging-windows-x86.yml
@@ -1,0 +1,43 @@
+name: Release Packaging Windows x86
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Git tag to checkout for release packaging"
+        required: true
+        type: string
+
+jobs:
+  build_windows_x86:
+    name: Build Windows x86 standalone binary
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Setup Python (x86)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          architecture: x86
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller rich
+          pip install .
+
+      - name: Build standalone binary
+        run: >-
+          python -m PyInstaller
+          --onefile
+          --name magnetar-windows-x86
+          src/magnetar/cli.py
+
+      - name: Upload Windows x86 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-windows-x86
+          path: dist/magnetar-windows-x86.exe

--- a/.github/workflows/release-packaging.yml
+++ b/.github/workflows/release-packaging.yml
@@ -107,195 +107,26 @@ jobs:
           path: ${{ steps.meta.outputs.notes_file }}
 
   build_macos:
-    name: Build macOS standalone binary (${{ matrix.target }})
+    name: Build macOS standalone binary
     needs: prepare
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: intel
-            runner: macos-13
-            binary_name: magnetar-macos-intel
-          - target: apple-silicon
-            runner: macos-14
-            binary_name: magnetar-macos-apple-silicon
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare.outputs.tag }}
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyinstaller rich
-          pip install .
-
-      - name: Build standalone binary
-        run: >-
-          python -m PyInstaller
-          --onefile
-          --name ${{ matrix.binary_name }}
-          src/magnetar/cli.py
-
-      - name: Upload macOS artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-assets-macos-${{ matrix.target }}
-          path: dist/${{ matrix.binary_name }}
+    uses: ./.github/workflows/release-packaging-macos.yml
+    with:
+      tag: ${{ needs.prepare.outputs.tag }}
 
   build_windows_x86:
     name: Build Windows x86 standalone binary
     needs: prepare
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare.outputs.tag }}
-
-      - name: Setup Python (x86)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          architecture: x86
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyinstaller rich
-          pip install .
-
-      - name: Build standalone binary
-        run: >-
-          python -m PyInstaller
-          --onefile
-          --name magnetar-windows-x86
-          src/magnetar/cli.py
-
-      - name: Upload Windows x86 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-assets-windows-x86
-          path: dist/magnetar-windows-x86.exe
+    uses: ./.github/workflows/release-packaging-windows-x86.yml
+    with:
+      tag: ${{ needs.prepare.outputs.tag }}
 
   build_linux_packages:
     name: Build Linux package formats
     needs: prepare
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare.outputs.tag }}
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          if apt-cache show libfuse2 >/dev/null 2>&1; then
-            FUSE_PACKAGE="libfuse2"
-          else
-            FUSE_PACKAGE="libfuse2t64"
-          fi
-
-          sudo apt-get install -y ruby ruby-dev rpm squashfs-tools desktop-file-utils "$FUSE_PACKAGE"
-          sudo gem install --no-document fpm
-          python -m pip install --upgrade pip
-          pip install pyinstaller rich
-          pip install .
-
-      - name: Build Linux standalone binary
-        run: >-
-          python -m PyInstaller
-          --onefile
-          --name magnetar-linux-x86_64
-          src/magnetar/cli.py
-
-      - name: Build DEB and RPM packages
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          mkdir -p package-root/usr/local/bin
-          install -m 0755 dist/magnetar-linux-x86_64 package-root/usr/local/bin/magnetar
-
-          fpm -s dir -t deb -n magnetar -v "$VERSION" --architecture amd64 \
-            --description "Magnetar CLI" --url "https://github.com/${GITHUB_REPOSITORY}" \
-            -C package-root usr/local/bin/magnetar
-
-          fpm -s dir -t rpm -n magnetar -v "$VERSION" --architecture x86_64 \
-            --description "Magnetar CLI" --url "https://github.com/${GITHUB_REPOSITORY}" \
-            -C package-root usr/local/bin/magnetar
-
-      - name: Build AppImage
-        run: |
-          mkdir -p AppDir/usr/bin AppDir/usr/share/applications
-          install -m 0755 dist/magnetar-linux-x86_64 AppDir/usr/bin/magnetar
-          cat > AppDir/usr/share/applications/magnetar.desktop <<'EOF'
-          [Desktop Entry]
-          Name=Magnetar
-          Exec=magnetar
-          Type=Application
-          Categories=Utility;
-          Terminal=true
-          EOF
-          cp AppDir/usr/share/applications/magnetar.desktop AppDir/magnetar.desktop
-
-          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
-          chmod +x appimagetool
-          APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool AppDir magnetar-${{ needs.prepare.outputs.version }}-x86_64.AppImage
-
-      - name: Prepare snapcraft definition
-        run: |
-          mkdir -p snap
-          cat > snap/snapcraft.yaml <<'EOF'
-          name: magnetar
-          base: core22
-          version: '${{ needs.prepare.outputs.version }}'
-          summary: Magnetar CLI
-          description: |
-            Magnetar command line interface packaged as a snap.
-          grade: stable
-          confinement: strict
-
-          apps:
-            magnetar:
-              command: bin/magnetar
-
-          parts:
-            magnetar:
-              plugin: dump
-              source: dist
-              organize:
-                magnetar-linux-x86_64: bin/magnetar
-          EOF
-
-      - name: Build SNAP package
-        uses: snapcore/action-build@v1
-        with:
-          snapcraft-args: --destructive-mode
-
-      - name: Collect Linux packaging artifacts
-        run: |
-          mkdir -p release-assets
-          cp *.deb release-assets/
-          cp *.rpm release-assets/
-          cp *.AppImage release-assets/
-          cp *.snap release-assets/
-          cp dist/magnetar-linux-x86_64 release-assets/
-
-      - name: Upload Linux packaging artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-assets-linux-packaging
-          path: release-assets/*
+    uses: ./.github/workflows/release-packaging-linux.yml
+    with:
+      tag: ${{ needs.prepare.outputs.tag }}
+      version: ${{ needs.prepare.outputs.version }}
 
   github_release:
     name: Publish GitHub release with expanded artifacts


### PR DESCRIPTION
### **User description**
### Motivation
- Reduce complexity by splitting the monolithic release packaging workflow into separate, reusable OS-specific workflows while keeping the same pipeline entrypoints and behavior.
- Preserve the existing release metadata, tagging, and publishing orchestration so downstream consumers of artifacts are unaffected.

### Description
- Added three reusable workflow files: `.github/workflows/release-packaging-macos.yml`, `.github/workflows/release-packaging-windows-x86.yml`, and `.github/workflows/release-packaging-linux.yml` that implement the original per-platform build steps.
- Updated `.github/workflows/release-packaging.yml` to retain the `prepare` job (metadata, notes, tag creation, artifact upload) and delegate platform builds to the new workflows via `uses` with inputs `tag` and `version` where appropriate.
- Kept artifact names and publishing behavior unchanged (artifact uploads and the `github_release` job still consume `release-assets-macos-*`, `release-assets-windows-x86`, and `release-assets-linux-packaging`).
- Preserved the original packaging logic for macOS (Intel/Apple Silicon matrix), Windows x86, and Linux (binary + DEB/RPM/AppImage/SNAP) inside the new reusable workflows.

### Testing
- Ran `git diff --check` to ensure no whitespace or merge issues and it succeeded.
- Ran `python -m compileall -q src` to validate Python sources compile and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999db83e50883339007e5f7c9cfafb4)

## Summary by Sourcery

Split the release packaging workflow into OS-specific reusable workflows while preserving the existing release orchestration and artifacts.

Build:
- Introduce separate reusable GitHub Actions workflows for macOS, Windows x86, and Linux release packaging and invoke them from the main release-packaging workflow.

CI:
- Refactor the release packaging CI job definitions into OS-specific workflow_call workflows without changing artifact names or release publishing behavior.


___

### **Description**
- Split the monolithic release packaging workflow into separate reusable workflows for macOS, Windows x86, and Linux.
- Preserved existing release orchestration and artifact naming conventions.
- Each OS-specific workflow handles its own build steps and artifact uploads.
- Maintained compatibility for downstream consumers of artifacts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-packaging-linux.yml</strong><dd><code>New Linux Release Packaging Workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-packaging-linux.yml
<li>Added a new workflow for Linux release packaging.<br> <li> Implemented steps for building DEB, RPM, AppImage, and SNAP packages.<br> <li> Included artifact upload steps for Linux packages.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/57/files#diff-d7e9fa2e730f468de61bf95eeb74baa73d055be6e206168306c5675d130878de">+127/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>release-packaging-macos.yml</strong><dd><code>New macOS Release Packaging Workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-packaging-macos.yml
<li>Introduced a new workflow for macOS release packaging.<br> <li> Added steps for building standalone binaries for Intel and Apple <br>Silicon.<br> <li> Included artifact upload steps for macOS binaries.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/57/files#diff-da3c91c7dcb675d65557c18800e5b484d5927e984adc92c404ad7be26f634e91">+52/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>release-packaging-windows-x86.yml</strong><dd><code>New Windows x86 Release Packaging Workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-packaging-windows-x86.yml
<li>Created a new workflow for Windows x86 release packaging.<br> <li> Added steps for building standalone binaries for Windows.<br> <li> Included artifact upload steps for Windows binaries.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/57/files#diff-18e83b30bb9a0947033747c836854a15a2c4034a493a1bcb3e881ced55bc3ec8">+43/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>release-packaging.yml</strong><dd><code>Refactor Main Release Packaging Workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-packaging.yml
<li>Refactored existing workflow to call new OS-specific workflows.<br> <li> Removed inline build steps for macOS, Windows, and Linux.<br> <li> Updated job dependencies to use new workflows.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/57/files#diff-19ecbe3ea7a31867299a2cc936f56bebbc1abfcb43b7267ac23e78bcf895a1be">+11/-180</a></td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

