### PR TITLE
fix(ci): resolve SDK subpath imports in UI tests

### DIFF
--- a/apps/magnetar-ui/tsconfig.test.json
+++ b/apps/magnetar-ui/tsconfig.test.json
@@ -1,8 +1,29 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
+    "baseUrl": ".",
+    "rootDir": "../..",
     "outDir": "dist-test",
+    "paths": {
+      "@magnetar/magnetar-sdk/agent": [
+        "../../packages/magnetar-sdk/src/agent.ts"
+      ],
+      "@magnetar/magnetar-sdk/interfaces": [
+        "../../packages/magnetar-sdk/src/interfaces.ts"
+      ],
+      "@magnetar/magnetar-sdk/models": [
+        "../../packages/magnetar-sdk/src/models.ts"
+      ],
+      "@magnetar/magnetar-sdk/providers/lm-studio": [
+        "../../packages/magnetar-sdk/src/providers/lm-studio.ts"
+      ],
+      "@magnetar/magnetar-sdk/tools/node-filesystem": [
+        "../../packages/magnetar-sdk/src/tools/node-filesystem.ts"
+      ],
+      "@magnetar/magnetar-sdk/tools/web-filesystem": [
+        "../../packages/magnetar-sdk/src/tools/web-filesystem.ts"
+      ]
+    },
     "types": [
       "node",
       "vitest/globals"

--- a/apps/magnetar-ui/vitest.config.ts
+++ b/apps/magnetar-ui/vitest.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@magnetar/magnetar-sdk/agent': fileURLToPath(new URL('../../packages/magnetar-sdk/src/agent.ts', import.meta.url)),
+      '@magnetar/magnetar-sdk/interfaces': fileURLToPath(new URL('../../packages/magnetar-sdk/src/interfaces.ts', import.meta.url)),
+      '@magnetar/magnetar-sdk/models': fileURLToPath(new URL('../../packages/magnetar-sdk/src/models.ts', import.meta.url)),
+      '@magnetar/magnetar-sdk/providers/lm-studio': fileURLToPath(new URL('../../packages/magnetar-sdk/src/providers/lm-studio.ts', import.meta.url)),
+      '@magnetar/magnetar-sdk/tools/node-filesystem': fileURLToPath(new URL('../../packages/magnetar-sdk/src/tools/node-filesystem.ts', import.meta.url)),
+      '@magnetar/magnetar-sdk/tools/web-filesystem': fileURLToPath(new URL('../../packages/magnetar-sdk/src/tools/web-filesystem.ts', import.meta.url)),
+    },
+  },
   test: {
     environment: 'node',
     include: ['tests/**/*.spec.ts'],


### PR DESCRIPTION
This PR resolves SDK subpath imports in UI tests by correctly mapping internal SDK paths in the CI environment. This fixes build failures and improves test reliability.

Affected Tasks: task-ts-qa-107
BITACORA entry:
- **2026-03-11 11:53**: Resolved SDK subpath imports in UI tests in branch fix/ci-sdk-subpath-resolution.