### PR TITLE
feat: make policy screen detail state real

### DIFF
--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -15,6 +15,7 @@ import { UiBadgeComponent, BadgeStatus } from './ui/badge.component.js';
 import { UiIconComponent } from './ui/icon.component.js';
 import { MOCK_AGENTS, MOCK_RUNS, MOCK_TOOLS, MOCK_POLICIES, Agent, Run, Tool, Policy } from './ui/mock-data.js';
 import { ChatBlock, ChatMessage } from './core/models/chat.js';
+import { PolicyScreenState } from './core/models/policy-screen-state.js';
 import { ProviderConfig, ProviderPreset } from './core/models/provider-config.js';
 import { ChatSessionService } from './core/services/chat-session.service.js';
 import { ProviderConfigService } from './core/services/provider-config.service.js';
@@ -1772,8 +1773,8 @@ export class ProvidersScreen {
           <div class="bg-[#0f0f13] border border-white/5 rounded-2xl p-5 shadow-lg">
             <h3 class="text-lg font-medium text-white mb-4">Active Policies</h3>
             <div class="space-y-3">
-              <div *ngFor="let policy of policies" class="group bg-[#0a0a0d] border border-white/5 hover:border-violet-500/30 rounded-xl p-4 transition-all cursor-pointer shadow-sm relative overflow-hidden" (click)="selectedPolicy = policy" [ngClass]="{'border-violet-500/50 bg-violet-500/5': selectedPolicy?.id === policy.id}">
-                <div *ngIf="selectedPolicy?.id === policy.id" class="absolute left-0 top-0 bottom-0 w-1 bg-violet-500"></div>
+              <div *ngFor="let policy of policies()" class="group bg-[#0a0a0d] border border-white/5 hover:border-violet-500/30 rounded-xl p-4 transition-all cursor-pointer shadow-sm relative overflow-hidden" (click)="selectPolicy(policy.id)" [ngClass]="{'border-violet-500/50 bg-violet-500/5': selectedPolicyId() === policy.id}">
+                <div *ngIf="selectedPolicyId() === policy.id" class="absolute left-0 top-0 bottom-0 w-1 bg-violet-500"></div>
                 <div class="flex items-start justify-between gap-4">
                   <div class="flex items-start gap-4">
                     <div class="w-10 h-10 rounded-lg bg-white/5 border border-white/10 flex items-center justify-center mt-1 group-hover:bg-white/10 transition-colors" [ngClass]="{'text-red-400': policy.riskLevel === 'Critical', 'text-amber-400': policy.riskLevel === 'High', 'text-blue-400': policy.riskLevel === 'Medium', 'text-emerald-400': policy.riskLevel === 'Low'}">
@@ -1805,14 +1806,14 @@ export class ProvidersScreen {
         </div>
 
         <aside class="sticky top-24 space-y-6">
-          <div *ngIf="selectedPolicy; else emptySelection" class="bg-[#0a0a0d] border border-violet-500/20 rounded-2xl p-5 shadow-2xl relative overflow-hidden">
+          <div *ngIf="draftPolicy() as draft; else emptySelection" class="bg-[#0a0a0d] border border-violet-500/20 rounded-2xl p-5 shadow-2xl relative overflow-hidden">
              <div class="absolute -right-10 -top-10 w-40 h-40 bg-violet-500/10 blur-3xl rounded-full pointer-events-none"></div>
 
              <div class="flex items-center justify-between mb-6 relative z-10">
                <h3 class="text-lg font-medium text-white flex items-center gap-2">
                  <ui-icon name="settings" [size]="18" cssClass="text-violet-400"></ui-icon> Policy Details
                </h3>
-               <button class="p-1.5 hover:bg-white/10 rounded-lg transition-colors text-zinc-400 hover:text-white" (click)="selectedPolicy = null" aria-label="Close details">
+               <button class="p-1.5 hover:bg-white/10 rounded-lg transition-colors text-zinc-400 hover:text-white" (click)="closeDetails()" aria-label="Close details">
                  <ui-icon name="x" [size]="16"></ui-icon>
                </button>
              </div>
@@ -1820,38 +1821,50 @@ export class ProvidersScreen {
              <div class="space-y-6 relative z-10">
                <div>
                  <label class="block text-xs uppercase tracking-wider text-zinc-500 mb-2">Policy Name</label>
-                 <input type="text" [value]="selectedPolicy.name" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 transition-colors">
+                 <input type="text" [value]="draft.name" (input)="handleNameInput($event)" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 transition-colors">
                </div>
 
                <div>
                  <label class="block text-xs uppercase tracking-wider text-zinc-500 mb-2">Description</label>
-                 <textarea rows="3" [value]="selectedPolicy.description" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 transition-colors"></textarea>
+                 <textarea rows="3" [value]="draft.description" (input)="handleDescriptionInput($event)" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 transition-colors"></textarea>
                </div>
 
                <div class="grid grid-cols-2 gap-4">
                   <div>
                     <label class="block text-xs uppercase tracking-wider text-zinc-500 mb-2">Risk Level</label>
-                    <select class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 appearance-none">
-                      <option [selected]="selectedPolicy.riskLevel === 'Low'">Low</option>
-                      <option [selected]="selectedPolicy.riskLevel === 'Medium'">Medium</option>
-                      <option [selected]="selectedPolicy.riskLevel === 'High'">High</option>
-                      <option [selected]="selectedPolicy.riskLevel === 'Critical'">Critical</option>
+                    <select [value]="draft.riskLevel" (change)="handleRiskLevelChange($event)" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 appearance-none">
+                      <option value="Low">Low</option>
+                      <option value="Medium">Medium</option>
+                      <option value="High">High</option>
+                      <option value="Critical">Critical</option>
                     </select>
                   </div>
                   <div>
                     <label class="block text-xs uppercase tracking-wider text-zinc-500 mb-2">Action</label>
-                    <select class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 appearance-none">
-                      <option [selected]="selectedPolicy.action === 'Auto-Approve'">Auto-Approve</option>
-                      <option [selected]="selectedPolicy.action === 'Require Review'">Require Review</option>
-                      <option [selected]="selectedPolicy.action === 'Simulate'">Simulate</option>
-                      <option [selected]="selectedPolicy.action === 'Block'">Block</option>
+                    <select [value]="draft.action" (change)="handleActionChange($event)" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 appearance-none">
+                      <option value="Auto-Approve">Auto-Approve</option>
+                      <option value="Require Review">Require Review</option>
+                      <option value="Simulate">Simulate</option>
+                      <option value="Block">Block</option>
                     </select>
                   </div>
                </div>
 
                <div class="pt-4 border-t border-white/5 flex gap-3">
-                 <button class="flex-1 bg-violet-600 hover:bg-violet-500 text-white py-2 rounded-lg text-sm font-medium transition-colors">Save Changes</button>
-                 <button class="px-4 py-2 border border-white/10 hover:bg-white/5 rounded-lg text-sm font-medium text-zinc-300 transition-colors">Cancel</button>
+                 <button
+                   (click)="saveChanges()"
+                   [disabled]="!hasUnsavedChanges()"
+                   class="flex-1 py-2 rounded-lg text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+                   [ngClass]="hasUnsavedChanges() ? 'bg-violet-600 hover:bg-violet-500 text-white' : 'bg-violet-600/40 text-white/70'">
+                   Save Changes
+                 </button>
+                 <button
+                   (click)="cancelChanges()"
+                   [disabled]="!hasUnsavedChanges()"
+                   class="px-4 py-2 border rounded-lg text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+                   [ngClass]="hasUnsavedChanges() ? 'border-white/10 hover:bg-white/5 text-zinc-300' : 'border-white/5 text-zinc-500'">
+                   Cancel
+                 </button>
                </div>
              </div>
           </div>
@@ -1871,14 +1884,66 @@ export class ProvidersScreen {
   `,
 })
 export class PolicyScreen {
-  public readonly policies: Policy[] = MOCK_POLICIES;
-  public selectedPolicy: Policy | null = null;
+  private readonly state = new PolicyScreenState(MOCK_POLICIES);
+  public readonly policies = this.state.policies;
+  public readonly selectedPolicyId = this.state.selectedPolicyId;
+  public readonly draftPolicy = this.state.draftPolicy;
+  public readonly selectedPolicy = this.state.selectedPolicy;
+  public readonly hasUnsavedChanges = this.state.hasUnsavedChanges;
 
-  public getPolicyStatusBadge(status: string): BadgeStatus {
+  public selectPolicy(policyId: string): void {
+    this.state.selectPolicy(policyId);
+  }
+
+  public closeDetails(): void {
+    this.state.closeDetails();
+  }
+
+  public updateDraftName(name: string): void {
+    this.state.updateDraftName(name);
+  }
+
+  public handleNameInput(event: Event): void {
+    this.updateDraftName(this.readInputValue(event));
+  }
+
+  public updateDraftDescription(description: string): void {
+    this.state.updateDraftDescription(description);
+  }
+
+  public handleDescriptionInput(event: Event): void {
+    this.updateDraftDescription(this.readInputValue(event));
+  }
+
+  public updateDraftRiskLevel(riskLevel: Policy['riskLevel']): void {
+    this.state.updateDraftRiskLevel(riskLevel);
+  }
+
+  public handleRiskLevelChange(event: Event): void {
+    this.updateDraftRiskLevel(this.readSelectValue(event) as Policy['riskLevel']);
+  }
+
+  public updateDraftAction(action: Policy['action']): void {
+    this.state.updateDraftAction(action);
+  }
+
+  public handleActionChange(event: Event): void {
+    this.updateDraftAction(this.readSelectValue(event) as Policy['action']);
+  }
+
+  public saveChanges(): void {
+    this.state.saveChanges();
+  }
+
+  public cancelChanges(): void {
+    this.state.cancelChanges();
+  }
+
+  public getPolicyStatusBadge(status: Policy['status']): BadgeStatus {
     return status === 'active' ? 'active' : 'idle';
   }
 
-  public getRiskColor(riskLevel: string): string {
+  public getRiskColor(riskLevel: Policy['riskLevel']): string {
     switch (riskLevel) {
       case 'Critical': return 'text-red-400';
       case 'High': return 'text-amber-400';
@@ -1886,6 +1951,14 @@ export class PolicyScreen {
       case 'Low': return 'text-emerald-400';
       default: return 'text-zinc-400';
     }
+  }
+
+  private readInputValue(event: Event): string {
+    return (event.target as HTMLInputElement | HTMLTextAreaElement).value;
+  }
+
+  private readSelectValue(event: Event): string {
+    return (event.target as HTMLSelectElement).value;
   }
 }
 

--- a/apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
+++ b/apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
@@ -1,0 +1,101 @@
+import { computed, signal } from '@angular/core';
+
+import { Policy } from '../../ui/mock-data.js';
+
+export class PolicyScreenState {
+  public readonly policies;
+  public readonly selectedPolicyId = signal<string | null>(null);
+  public readonly draftPolicy = signal<Policy | null>(null);
+  public readonly selectedPolicy;
+  public readonly hasUnsavedChanges;
+
+  public constructor(policies: Policy[]) {
+    this.policies = signal<Policy[]>(policies.map((policy) => this.clonePolicy(policy)));
+    this.selectedPolicy = computed(() => {
+      const selectedPolicyId = this.selectedPolicyId();
+      if (!selectedPolicyId) {
+        return null;
+      }
+
+      return this.policies().find((policy) => policy.id === selectedPolicyId) ?? null;
+    });
+    this.hasUnsavedChanges = computed(() => {
+      const selectedPolicy = this.selectedPolicy();
+      const draftPolicy = this.draftPolicy();
+      if (!selectedPolicy || !draftPolicy) {
+        return false;
+      }
+
+      return (
+        selectedPolicy.name !== draftPolicy.name ||
+        selectedPolicy.description !== draftPolicy.description ||
+        selectedPolicy.riskLevel !== draftPolicy.riskLevel ||
+        selectedPolicy.action !== draftPolicy.action
+      );
+    });
+  }
+
+  public selectPolicy(policyId: string): void {
+    const policy = this.policies().find((candidate) => candidate.id === policyId);
+    if (!policy) {
+      return;
+    }
+
+    this.selectedPolicyId.set(policy.id);
+    this.draftPolicy.set(this.clonePolicy(policy));
+  }
+
+  public closeDetails(): void {
+    this.selectedPolicyId.set(null);
+    this.draftPolicy.set(null);
+  }
+
+  public updateDraftName(name: string): void {
+    this.patchDraft({ name });
+  }
+
+  public updateDraftDescription(description: string): void {
+    this.patchDraft({ description });
+  }
+
+  public updateDraftRiskLevel(riskLevel: Policy['riskLevel']): void {
+    this.patchDraft({ riskLevel });
+  }
+
+  public updateDraftAction(action: Policy['action']): void {
+    this.patchDraft({ action });
+  }
+
+  public saveChanges(): void {
+    const selectedPolicy = this.selectedPolicy();
+    const draftPolicy = this.draftPolicy();
+    if (!selectedPolicy || !draftPolicy) {
+      return;
+    }
+
+    this.policies.update((policies) =>
+      policies.map((policy) => (policy.id === selectedPolicy.id ? this.clonePolicy(draftPolicy) : policy)),
+    );
+    this.draftPolicy.set(this.clonePolicy(draftPolicy));
+  }
+
+  public cancelChanges(): void {
+    const selectedPolicy = this.selectedPolicy();
+    if (!selectedPolicy) {
+      return;
+    }
+
+    this.draftPolicy.set(this.clonePolicy(selectedPolicy));
+  }
+
+  private patchDraft(patch: Partial<Policy>): void {
+    this.draftPolicy.update((draftPolicy) => (draftPolicy ? { ...draftPolicy, ...patch } : draftPolicy));
+  }
+
+  private clonePolicy(policy: Policy): Policy {
+    return {
+      ...policy,
+      tags: [...policy.tags],
+    };
+  }
+}

--- a/apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
+++ b/apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
@@ -1,13 +1,13 @@
-import { computed, signal } from '@angular/core';
+import { computed, signal, type Signal, type WritableSignal } from '@angular/core';
 
 import { Policy } from '../../ui/mock-data.js';
 
 export class PolicyScreenState {
-  public readonly policies;
-  public readonly selectedPolicyId = signal<string | null>(null);
-  public readonly draftPolicy = signal<Policy | null>(null);
-  public readonly selectedPolicy;
-  public readonly hasUnsavedChanges;
+  public readonly policies: WritableSignal<Policy[]>;
+  public readonly selectedPolicyId: WritableSignal<string | null> = signal<string | null>(null);
+  public readonly draftPolicy: WritableSignal<Policy | null> = signal<Policy | null>(null);
+  public readonly selectedPolicy: Signal<Policy | null>;
+  public readonly hasUnsavedChanges: Signal<boolean>;
 
   public constructor(policies: Policy[]) {
     this.policies = signal<Policy[]>(policies.map((policy) => this.clonePolicy(policy)));
@@ -36,6 +36,10 @@ export class PolicyScreenState {
   }
 
   public selectPolicy(policyId: string): void {
+    if (this.selectedPolicyId() === policyId) {
+      return;
+    }
+
     const policy = this.policies().find((candidate) => candidate.id === policyId);
     if (!policy) {
       return;

--- a/apps/magnetar-ui/tests/policy-screen.spec.ts
+++ b/apps/magnetar-ui/tests/policy-screen.spec.ts
@@ -68,6 +68,19 @@ describe('PolicyScreen', () => {
     expect(screen.hasUnsavedChanges()).toBe(false);
   });
 
+  it('preserves unsaved draft changes when the already-selected policy is clicked again', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-03');
+    screen.updateDraftDescription('Unsaved draft description');
+
+    screen.selectPolicy('pol-03');
+
+    expect(screen.selectedPolicy()?.description).toBe('Any outbound network call to untrusted domains is strictly blocked.');
+    expect(screen.draftPolicy()?.description).toBe('Unsaved draft description');
+    expect(screen.hasUnsavedChanges()).toBe(true);
+  });
+
   it('clears the detail panel state when closed', () => {
     const screen = new PolicyScreenState(MOCK_POLICIES);
 

--- a/apps/magnetar-ui/tests/policy-screen.spec.ts
+++ b/apps/magnetar-ui/tests/policy-screen.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { PolicyScreenState } from '../src/app/core/models/policy-screen-state.js';
+import { MOCK_POLICIES } from '../src/app/ui/mock-data.js';
+
+describe('PolicyScreen', () => {
+  it('creates a draft copy when selecting a policy without mutating the source state', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-01');
+
+    expect(screen.selectedPolicy()?.id).toBe('pol-01');
+    expect(screen.draftPolicy()).toMatchObject({
+      id: 'pol-01',
+      name: 'Prevent File Deletion',
+    });
+
+    screen.updateDraftName('Prevent Production File Deletion');
+
+    expect(screen.draftPolicy()?.name).toBe('Prevent Production File Deletion');
+    expect(screen.selectedPolicy()?.name).toBe('Prevent File Deletion');
+    expect(screen.hasUnsavedChanges()).toBe(true);
+  });
+
+  it('commits draft updates back into the local policy collection on save', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-02');
+    screen.updateDraftDescription('SELECT-only queries remain auto-approved in the local PoC.');
+    screen.updateDraftAction('Require Review');
+
+    screen.saveChanges();
+
+    expect(screen.selectedPolicy()).toMatchObject({
+      id: 'pol-02',
+      description: 'SELECT-only queries remain auto-approved in the local PoC.',
+      action: 'Require Review',
+    });
+    expect(screen.draftPolicy()).toMatchObject({
+      id: 'pol-02',
+      description: 'SELECT-only queries remain auto-approved in the local PoC.',
+      action: 'Require Review',
+    });
+    expect(screen.hasUnsavedChanges()).toBe(false);
+  });
+
+  it('restores the original selected policy values on cancel', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-03');
+    screen.updateDraftRiskLevel('Critical');
+    screen.updateDraftAction('Simulate');
+
+    expect(screen.hasUnsavedChanges()).toBe(true);
+
+    screen.cancelChanges();
+
+    expect(screen.draftPolicy()).toMatchObject({
+      id: 'pol-03',
+      riskLevel: 'High',
+      action: 'Block',
+    });
+    expect(screen.selectedPolicy()).toMatchObject({
+      id: 'pol-03',
+      riskLevel: 'High',
+      action: 'Block',
+    });
+    expect(screen.hasUnsavedChanges()).toBe(false);
+  });
+
+  it('clears the detail panel state when closed', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-04');
+    screen.closeDetails();
+
+    expect(screen.selectedPolicy()).toBeNull();
+    expect(screen.draftPolicy()).toBeNull();
+    expect(screen.selectedPolicyId()).toBeNull();
+  });
+
+  it('keeps state unchanged when selection or edit actions are invoked without a valid selected policy', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+    const originalPolicies = screen.policies();
+
+    expect(screen.hasUnsavedChanges()).toBe(false);
+
+    screen.selectPolicy('missing-policy');
+    screen.updateDraftName('No-op name');
+    screen.updateDraftDescription('No-op description');
+    screen.updateDraftRiskLevel('Critical');
+    screen.updateDraftAction('Block');
+    screen.saveChanges();
+    screen.cancelChanges();
+
+    expect(screen.selectedPolicy()).toBeNull();
+    expect(screen.draftPolicy()).toBeNull();
+    expect(screen.selectedPolicyId()).toBeNull();
+    expect(screen.hasUnsavedChanges()).toBe(false);
+    expect(screen.policies()).toEqual(originalPolicies);
+  });
+
+  it('treats a stale selected policy id as no active selection', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectedPolicyId.set('stale-policy-id');
+
+    expect(screen.selectedPolicy()).toBeNull();
+    expect(screen.hasUnsavedChanges()).toBe(false);
+  });
+});

--- a/branches/fix-policy-screen-real-state-254/CHANGES.md
+++ b/branches/fix-policy-screen-real-state-254/CHANGES.md
@@ -1,0 +1,10 @@
+# Changes for fix/policy-screen-real-state-254
+
+## Summary
+Solve issue `#254` by making the Policy Center detail panel truthful and locally interactive instead of presenting fake editing controls.
+
+## Changes
+- Reworked `PolicyScreen` to manage local policy state, selection state, and draft editing state explicitly.
+- Wired the detail panel inputs and selects to real draft-update handlers.
+- Made `Save Changes`, `Cancel`, and close behavior operate on real local draft state.
+- Added focused tests that cover policy selection, draft editing, save behavior, cancel behavior, and detail-panel reset behavior.


### PR DESCRIPTION
### **User description**
## Summary
- solve #254 by replacing fake Policy Center edit controls with real local draft state
- extract policy detail state into a dedicated `PolicyScreenState` model so the behavior is testable without the Angular app shell
- add focused Policy Center tests covering selection, draft editing, save, cancel, and stale-selection edge cases

## Testing
- npm --prefix apps/magnetar-ui run typecheck
- npm --prefix apps/magnetar-ui run test:ci


___

### **Description**
- Enhanced the `PolicyScreen` to manage real local draft state instead of using fake controls.
- Introduced `PolicyScreenState` for better state management and testability.
- Updated detail panel to reflect real-time changes in policy drafts.
- Added comprehensive tests covering selection, editing, saving, and canceling actions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.component.ts</strong><dd><code>Refactor PolicyScreen to Use Real State Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/magnetar-ui/src/app/app.component.ts
<li>Introduced <code>PolicyScreenState</code> for managing policy state.<br> <li> Updated policy selection and draft management logic.<br> <li> Enhanced detail panel to reflect real draft state.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/257/files#diff-98cd05c775278d9d124e85dfbb98bf94f9bb01c0ea490ee52abea54a14485673">+95/-22</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>policy-screen-state.ts</strong><dd><code>Add PolicyScreenState Class for Local State Management</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
<li>Created <code>PolicyScreenState</code> class for local state management.<br> <li> Implemented methods for selecting policies and managing drafts.<br> <li> Added logic for handling unsaved changes and saving drafts.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/257/files#diff-f72e72f02bfb12a328c0d112fe6f012f86372f7de8356e21ce26a24c19ec8f7c">+101/-0</a>&nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>policy-screen.spec.ts</strong><dd><code>Implement Tests for PolicyScreenState Functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/magnetar-ui/tests/policy-screen.spec.ts
<li>Added unit tests for <code>PolicyScreenState</code> functionality.<br> <li> Covered policy selection, draft updates, and state restoration.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/257/files#diff-ecbd7edeffdc381d8817ca48dea285dd19357fca3439700de6967b5793c09fbd">+111/-0</a>&nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGES.md</strong><dd><code>Update CHANGES.md with PR Summary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

branches/fix-policy-screen-real-state-254/CHANGES.md
<li>Documented changes made in the PR.<br> <li> Summarized enhancements and fixes related to issue <code>#254</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/257/files#diff-90e4c636d6b0504d13a89f20bb77773c67e959a05aeaaf87d8c522d83a73732a">+10/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

