### PR TITLE
docs: make policy center placeholders explicit

### DIFF
--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -1760,13 +1760,15 @@ export class ProvidersScreen {
         </div>
         <div class="flex items-center gap-3">
           <button
-            disabled
+            type="button"
+            aria-disabled="true"
             title="Planned follow-up: audit-log navigation is not implemented in this PoC."
             class="px-4 py-2 rounded-lg border border-white/5 bg-white/[0.03] text-sm font-medium text-zinc-500 cursor-not-allowed opacity-70">
             Audit Logs (Planned)
           </button>
           <button
-            disabled
+            type="button"
+            aria-disabled="true"
             title="Planned follow-up: policy creation flow is not implemented in this PoC."
             class="px-4 py-2 rounded-lg border border-violet-500/20 bg-violet-500/10 text-violet-200/70 text-sm font-medium cursor-not-allowed opacity-70 flex items-center gap-2">
             <ui-icon name="plus" [size]="16"></ui-icon> Create Policy (Planned)

--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -1759,12 +1759,26 @@ export class ProvidersScreen {
           </p>
         </div>
         <div class="flex items-center gap-3">
-          <button class="px-4 py-2 rounded-lg border border-white/10 bg-white/5 text-sm font-medium text-white hover:bg-white/10 transition-colors">
-            Audit Logs
+          <button
+            disabled
+            title="Planned follow-up: audit-log navigation is not implemented in this PoC."
+            class="px-4 py-2 rounded-lg border border-white/5 bg-white/[0.03] text-sm font-medium text-zinc-500 cursor-not-allowed opacity-70">
+            Audit Logs (Planned)
           </button>
-          <button class="px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-sm font-medium shadow-[0_0_15px_rgba(139,92,246,0.4)] transition-all flex items-center gap-2">
-            <ui-icon name="plus" [size]="16"></ui-icon> Create Policy
+          <button
+            disabled
+            title="Planned follow-up: policy creation flow is not implemented in this PoC."
+            class="px-4 py-2 rounded-lg border border-violet-500/20 bg-violet-500/10 text-violet-200/70 text-sm font-medium cursor-not-allowed opacity-70 flex items-center gap-2">
+            <ui-icon name="plus" [size]="16"></ui-icon> Create Policy (Planned)
           </button>
+        </div>
+      </div>
+
+      <div class="rounded-2xl border border-violet-500/15 bg-violet-500/5 px-4 py-3 text-sm text-violet-100/80 flex items-start gap-3">
+        <ui-icon name="shield" [size]="16" cssClass="text-violet-300 mt-0.5"></ui-icon>
+        <div class="leading-6">
+          This Policy Center slice is a local governance PoC. Policy inspection and local policy editing are active here;
+          audit-log navigation and policy creation remain planned follow-up flows.
         </div>
       </div>
 

--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -1776,7 +1776,7 @@ export class ProvidersScreen {
         </div>
       </div>
 
-      <div class="rounded-2xl border border-violet-500/15 bg-violet-500/5 px-4 py-3 text-sm text-violet-100/80 flex items-start gap-3">
+      <div role="status" class="rounded-2xl border border-violet-500/15 bg-violet-500/5 px-4 py-3 text-sm text-violet-100/80 flex items-start gap-3">
         <ui-icon name="shield" [size]="16" cssClass="text-violet-300 mt-0.5"></ui-icon>
         <div class="leading-6">
           This Policy Center slice is a local governance PoC. Policy inspection and local policy editing are active here;

--- a/branches/fix-policy-center-explicit-placeholders-255/CHANGES.md
+++ b/branches/fix-policy-center-explicit-placeholders-255/CHANGES.md
@@ -1,0 +1,9 @@
+# Changes for fix/policy-center-explicit-placeholders-255
+
+## Summary
+Solve issue `#255` by making the remaining Policy Center dead-end actions explicit placeholders instead of presenting them as active governance flows.
+
+## Changes
+- Disabled the `Audit Logs` and `Create Policy` header actions in the Policy Center PoC.
+- Relabeled those actions as planned follow-up work and added explanatory tooltip text.
+- Added a visible PoC-boundary note clarifying that local policy inspection/editing is active while audit-log navigation and policy creation are still planned.


### PR DESCRIPTION
## Summary
- solve #255 by making the remaining Policy Center dead-end actions explicit planned placeholders
- disable and relabel `Audit Logs` and `Create Policy` so the PoC no longer implies active governance flows that do not exist yet
- add a visible Policy Center note clarifying that local policy inspection/editing is active while audit-log navigation and policy creation are still planned

## Testing
- npm --prefix apps/magnetar-ui run typecheck
- npm --prefix apps/magnetar-ui run test:ci

## Summary by Sourcery

Clarify the Policy Center PoC boundaries by explicitly marking non-functional governance actions as planned placeholders and documenting the change.

Enhancements:
- Disable and relabel the Policy Center header Audit Logs and Create Policy actions as planned, non-interactive placeholders with explanatory tooltips.
- Add an in-page note explaining that only local policy inspection and editing are active while audit-log navigation and policy creation remain future work.

Documentation:
- Add a CHANGES entry documenting the Policy Center placeholder updates and scope clarification.