### PR TITLE
Integrate Policy Center follow-up fixes into PR #250 branch

### DIFF
--- a/apps/magnetar-ui/package-lock.json
+++ b/apps/magnetar-ui/package-lock.json
@@ -4337,6 +4337,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4354,6 +4357,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4371,6 +4377,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4388,6 +4397,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4405,6 +4417,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4422,6 +4437,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4439,6 +4457,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5388,6 +5409,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5405,6 +5429,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5422,6 +5449,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5439,6 +5469,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/apps/magnetar-ui/package-lock.json
+++ b/apps/magnetar-ui/package-lock.json
@@ -4337,9 +4337,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4357,9 +4354,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4377,9 +4371,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4397,9 +4388,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4417,9 +4405,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4437,9 +4422,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4457,9 +4439,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5409,9 +5388,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5429,9 +5405,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5449,9 +5422,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5469,9 +5439,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -1760,13 +1760,15 @@ export class ProvidersScreen {
         </div>
         <div class="flex items-center gap-3">
           <button
-            disabled
+            type="button"
+            aria-disabled="true"
             title="Planned follow-up: audit-log navigation is not implemented in this PoC."
             class="px-4 py-2 rounded-lg border border-white/5 bg-white/[0.03] text-sm font-medium text-zinc-500 cursor-not-allowed opacity-70">
             Audit Logs (Planned)
           </button>
           <button
-            disabled
+            type="button"
+            aria-disabled="true"
             title="Planned follow-up: policy creation flow is not implemented in this PoC."
             class="px-4 py-2 rounded-lg border border-violet-500/20 bg-violet-500/10 text-violet-200/70 text-sm font-medium cursor-not-allowed opacity-70 flex items-center gap-2">
             <ui-icon name="plus" [size]="16"></ui-icon> Create Policy (Planned)

--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -15,6 +15,7 @@ import { UiBadgeComponent, BadgeStatus } from './ui/badge.component.js';
 import { UiIconComponent } from './ui/icon.component.js';
 import { MOCK_AGENTS, MOCK_RUNS, MOCK_TOOLS, MOCK_POLICIES, Agent, Run, Tool, Policy } from './ui/mock-data.js';
 import { ChatBlock, ChatMessage } from './core/models/chat.js';
+import { PolicyScreenState } from './core/models/policy-screen-state.js';
 import { ProviderConfig, ProviderPreset } from './core/models/provider-config.js';
 import { ChatSessionService } from './core/services/chat-session.service.js';
 import { ProviderConfigService } from './core/services/provider-config.service.js';
@@ -1772,8 +1773,8 @@ export class ProvidersScreen {
           <div class="bg-[#0f0f13] border border-white/5 rounded-2xl p-5 shadow-lg">
             <h3 class="text-lg font-medium text-white mb-4">Active Policies</h3>
             <div class="space-y-3">
-              <div *ngFor="let policy of policies" class="group bg-[#0a0a0d] border border-white/5 hover:border-violet-500/30 rounded-xl p-4 transition-all cursor-pointer shadow-sm relative overflow-hidden" (click)="selectedPolicy = policy" [ngClass]="{'border-violet-500/50 bg-violet-500/5': selectedPolicy?.id === policy.id}">
-                <div *ngIf="selectedPolicy?.id === policy.id" class="absolute left-0 top-0 bottom-0 w-1 bg-violet-500"></div>
+              <div *ngFor="let policy of policies()" class="group bg-[#0a0a0d] border border-white/5 hover:border-violet-500/30 rounded-xl p-4 transition-all cursor-pointer shadow-sm relative overflow-hidden" (click)="selectPolicy(policy.id)" [ngClass]="{'border-violet-500/50 bg-violet-500/5': selectedPolicyId() === policy.id}">
+                <div *ngIf="selectedPolicyId() === policy.id" class="absolute left-0 top-0 bottom-0 w-1 bg-violet-500"></div>
                 <div class="flex items-start justify-between gap-4">
                   <div class="flex items-start gap-4">
                     <div class="w-10 h-10 rounded-lg bg-white/5 border border-white/10 flex items-center justify-center mt-1 group-hover:bg-white/10 transition-colors" [ngClass]="{'text-red-400': policy.riskLevel === 'Critical', 'text-amber-400': policy.riskLevel === 'High', 'text-blue-400': policy.riskLevel === 'Medium', 'text-emerald-400': policy.riskLevel === 'Low'}">
@@ -1805,14 +1806,14 @@ export class ProvidersScreen {
         </div>
 
         <aside class="sticky top-24 space-y-6">
-          <div *ngIf="selectedPolicy; else emptySelection" class="bg-[#0a0a0d] border border-violet-500/20 rounded-2xl p-5 shadow-2xl relative overflow-hidden">
+          <div *ngIf="draftPolicy() as draft; else emptySelection" class="bg-[#0a0a0d] border border-violet-500/20 rounded-2xl p-5 shadow-2xl relative overflow-hidden">
              <div class="absolute -right-10 -top-10 w-40 h-40 bg-violet-500/10 blur-3xl rounded-full pointer-events-none"></div>
 
              <div class="flex items-center justify-between mb-6 relative z-10">
                <h3 class="text-lg font-medium text-white flex items-center gap-2">
                  <ui-icon name="settings" [size]="18" cssClass="text-violet-400"></ui-icon> Policy Details
                </h3>
-               <button class="p-1.5 hover:bg-white/10 rounded-lg transition-colors text-zinc-400 hover:text-white" (click)="selectedPolicy = null" aria-label="Close details">
+               <button class="p-1.5 hover:bg-white/10 rounded-lg transition-colors text-zinc-400 hover:text-white" (click)="closeDetails()" aria-label="Close details">
                  <ui-icon name="x" [size]="16"></ui-icon>
                </button>
              </div>
@@ -1820,38 +1821,50 @@ export class ProvidersScreen {
              <div class="space-y-6 relative z-10">
                <div>
                  <label class="block text-xs uppercase tracking-wider text-zinc-500 mb-2">Policy Name</label>
-                 <input type="text" [value]="selectedPolicy.name" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 transition-colors">
+                 <input type="text" [value]="draft.name" (input)="handleNameInput($event)" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 transition-colors">
                </div>
 
                <div>
                  <label class="block text-xs uppercase tracking-wider text-zinc-500 mb-2">Description</label>
-                 <textarea rows="3" [value]="selectedPolicy.description" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 transition-colors"></textarea>
+                 <textarea rows="3" [value]="draft.description" (input)="handleDescriptionInput($event)" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 transition-colors"></textarea>
                </div>
 
                <div class="grid grid-cols-2 gap-4">
                   <div>
                     <label class="block text-xs uppercase tracking-wider text-zinc-500 mb-2">Risk Level</label>
-                    <select class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 appearance-none">
-                      <option [selected]="selectedPolicy.riskLevel === 'Low'">Low</option>
-                      <option [selected]="selectedPolicy.riskLevel === 'Medium'">Medium</option>
-                      <option [selected]="selectedPolicy.riskLevel === 'High'">High</option>
-                      <option [selected]="selectedPolicy.riskLevel === 'Critical'">Critical</option>
+                    <select [value]="draft.riskLevel" (change)="handleRiskLevelChange($event)" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 appearance-none">
+                      <option value="Low">Low</option>
+                      <option value="Medium">Medium</option>
+                      <option value="High">High</option>
+                      <option value="Critical">Critical</option>
                     </select>
                   </div>
                   <div>
                     <label class="block text-xs uppercase tracking-wider text-zinc-500 mb-2">Action</label>
-                    <select class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 appearance-none">
-                      <option [selected]="selectedPolicy.action === 'Auto-Approve'">Auto-Approve</option>
-                      <option [selected]="selectedPolicy.action === 'Require Review'">Require Review</option>
-                      <option [selected]="selectedPolicy.action === 'Simulate'">Simulate</option>
-                      <option [selected]="selectedPolicy.action === 'Block'">Block</option>
+                    <select [value]="draft.action" (change)="handleActionChange($event)" class="w-full bg-[#050508] border border-white/10 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-violet-500/50 appearance-none">
+                      <option value="Auto-Approve">Auto-Approve</option>
+                      <option value="Require Review">Require Review</option>
+                      <option value="Simulate">Simulate</option>
+                      <option value="Block">Block</option>
                     </select>
                   </div>
                </div>
 
                <div class="pt-4 border-t border-white/5 flex gap-3">
-                 <button class="flex-1 bg-violet-600 hover:bg-violet-500 text-white py-2 rounded-lg text-sm font-medium transition-colors">Save Changes</button>
-                 <button class="px-4 py-2 border border-white/10 hover:bg-white/5 rounded-lg text-sm font-medium text-zinc-300 transition-colors">Cancel</button>
+                 <button
+                   (click)="saveChanges()"
+                   [disabled]="!hasUnsavedChanges()"
+                   class="flex-1 py-2 rounded-lg text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+                   [ngClass]="hasUnsavedChanges() ? 'bg-violet-600 hover:bg-violet-500 text-white' : 'bg-violet-600/40 text-white/70'">
+                   Save Changes
+                 </button>
+                 <button
+                   (click)="cancelChanges()"
+                   [disabled]="!hasUnsavedChanges()"
+                   class="px-4 py-2 border rounded-lg text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+                   [ngClass]="hasUnsavedChanges() ? 'border-white/10 hover:bg-white/5 text-zinc-300' : 'border-white/5 text-zinc-500'">
+                   Cancel
+                 </button>
                </div>
              </div>
           </div>
@@ -1871,14 +1884,66 @@ export class ProvidersScreen {
   `,
 })
 export class PolicyScreen {
-  public readonly policies: Policy[] = MOCK_POLICIES;
-  public selectedPolicy: Policy | null = null;
+  private readonly state = new PolicyScreenState(MOCK_POLICIES);
+  public readonly policies = this.state.policies;
+  public readonly selectedPolicyId = this.state.selectedPolicyId;
+  public readonly draftPolicy = this.state.draftPolicy;
+  public readonly selectedPolicy = this.state.selectedPolicy;
+  public readonly hasUnsavedChanges = this.state.hasUnsavedChanges;
 
-  public getPolicyStatusBadge(status: string): BadgeStatus {
+  public selectPolicy(policyId: string): void {
+    this.state.selectPolicy(policyId);
+  }
+
+  public closeDetails(): void {
+    this.state.closeDetails();
+  }
+
+  public updateDraftName(name: string): void {
+    this.state.updateDraftName(name);
+  }
+
+  public handleNameInput(event: Event): void {
+    this.updateDraftName(this.readInputValue(event));
+  }
+
+  public updateDraftDescription(description: string): void {
+    this.state.updateDraftDescription(description);
+  }
+
+  public handleDescriptionInput(event: Event): void {
+    this.updateDraftDescription(this.readInputValue(event));
+  }
+
+  public updateDraftRiskLevel(riskLevel: Policy['riskLevel']): void {
+    this.state.updateDraftRiskLevel(riskLevel);
+  }
+
+  public handleRiskLevelChange(event: Event): void {
+    this.updateDraftRiskLevel(this.readSelectValue(event) as Policy['riskLevel']);
+  }
+
+  public updateDraftAction(action: Policy['action']): void {
+    this.state.updateDraftAction(action);
+  }
+
+  public handleActionChange(event: Event): void {
+    this.updateDraftAction(this.readSelectValue(event) as Policy['action']);
+  }
+
+  public saveChanges(): void {
+    this.state.saveChanges();
+  }
+
+  public cancelChanges(): void {
+    this.state.cancelChanges();
+  }
+
+  public getPolicyStatusBadge(status: Policy['status']): BadgeStatus {
     return status === 'active' ? 'active' : 'idle';
   }
 
-  public getRiskColor(riskLevel: string): string {
+  public getRiskColor(riskLevel: Policy['riskLevel']): string {
     switch (riskLevel) {
       case 'Critical': return 'text-red-400';
       case 'High': return 'text-amber-400';
@@ -1886,6 +1951,14 @@ export class PolicyScreen {
       case 'Low': return 'text-emerald-400';
       default: return 'text-zinc-400';
     }
+  }
+
+  private readInputValue(event: Event): string {
+    return (event.target as HTMLInputElement | HTMLTextAreaElement).value;
+  }
+
+  private readSelectValue(event: Event): string {
+    return (event.target as HTMLSelectElement).value;
   }
 }
 

--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -1759,12 +1759,28 @@ export class ProvidersScreen {
           </p>
         </div>
         <div class="flex items-center gap-3">
-          <button class="px-4 py-2 rounded-lg border border-white/10 bg-white/5 text-sm font-medium text-white hover:bg-white/10 transition-colors">
-            Audit Logs
+          <button
+            type="button"
+            aria-disabled="true"
+            title="Planned follow-up: audit-log navigation is not implemented in this PoC."
+            class="px-4 py-2 rounded-lg border border-white/5 bg-white/[0.03] text-sm font-medium text-zinc-500 cursor-not-allowed opacity-70">
+            Audit Logs (Planned)
           </button>
-          <button class="px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-sm font-medium shadow-[0_0_15px_rgba(139,92,246,0.4)] transition-all flex items-center gap-2">
-            <ui-icon name="plus" [size]="16"></ui-icon> Create Policy
+          <button
+            type="button"
+            aria-disabled="true"
+            title="Planned follow-up: policy creation flow is not implemented in this PoC."
+            class="px-4 py-2 rounded-lg border border-violet-500/20 bg-violet-500/10 text-violet-200/70 text-sm font-medium cursor-not-allowed opacity-70 flex items-center gap-2">
+            <ui-icon name="plus" [size]="16"></ui-icon> Create Policy (Planned)
           </button>
+        </div>
+      </div>
+
+      <div role="status" class="rounded-2xl border border-violet-500/15 bg-violet-500/5 px-4 py-3 text-sm text-violet-100/80 flex items-start gap-3">
+        <ui-icon name="shield" [size]="16" cssClass="text-violet-300 mt-0.5"></ui-icon>
+        <div class="leading-6">
+          This Policy Center slice is a local governance PoC. Policy inspection and local policy editing are active here;
+          audit-log navigation and policy creation remain planned follow-up flows.
         </div>
       </div>
 

--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -1759,12 +1759,26 @@ export class ProvidersScreen {
           </p>
         </div>
         <div class="flex items-center gap-3">
-          <button class="px-4 py-2 rounded-lg border border-white/10 bg-white/5 text-sm font-medium text-white hover:bg-white/10 transition-colors">
-            Audit Logs
+          <button
+            disabled
+            title="Planned follow-up: audit-log navigation is not implemented in this PoC."
+            class="px-4 py-2 rounded-lg border border-white/5 bg-white/[0.03] text-sm font-medium text-zinc-500 cursor-not-allowed opacity-70">
+            Audit Logs (Planned)
           </button>
-          <button class="px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-sm font-medium shadow-[0_0_15px_rgba(139,92,246,0.4)] transition-all flex items-center gap-2">
-            <ui-icon name="plus" [size]="16"></ui-icon> Create Policy
+          <button
+            disabled
+            title="Planned follow-up: policy creation flow is not implemented in this PoC."
+            class="px-4 py-2 rounded-lg border border-violet-500/20 bg-violet-500/10 text-violet-200/70 text-sm font-medium cursor-not-allowed opacity-70 flex items-center gap-2">
+            <ui-icon name="plus" [size]="16"></ui-icon> Create Policy (Planned)
           </button>
+        </div>
+      </div>
+
+      <div class="rounded-2xl border border-violet-500/15 bg-violet-500/5 px-4 py-3 text-sm text-violet-100/80 flex items-start gap-3">
+        <ui-icon name="shield" [size]="16" cssClass="text-violet-300 mt-0.5"></ui-icon>
+        <div class="leading-6">
+          This Policy Center slice is a local governance PoC. Policy inspection and local policy editing are active here;
+          audit-log navigation and policy creation remain planned follow-up flows.
         </div>
       </div>
 

--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -1776,7 +1776,7 @@ export class ProvidersScreen {
         </div>
       </div>
 
-      <div class="rounded-2xl border border-violet-500/15 bg-violet-500/5 px-4 py-3 text-sm text-violet-100/80 flex items-start gap-3">
+      <div role="status" class="rounded-2xl border border-violet-500/15 bg-violet-500/5 px-4 py-3 text-sm text-violet-100/80 flex items-start gap-3">
         <ui-icon name="shield" [size]="16" cssClass="text-violet-300 mt-0.5"></ui-icon>
         <div class="leading-6">
           This Policy Center slice is a local governance PoC. Policy inspection and local policy editing are active here;

--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -14,7 +14,7 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { UiBadgeComponent, BadgeStatus } from './ui/badge.component.js';
 import { UiIconComponent } from './ui/icon.component.js';
 import { MOCK_AGENTS, MOCK_RUNS, MOCK_TOOLS, MOCK_POLICIES, Agent, Run, Tool, Policy } from './ui/mock-data.js';
-import { getPolicyStatusBadge, getRiskColor } from './ui/policy-helpers.js';
+import { PolicyPresentation } from './ui/policy-helpers.js';
 import { ChatBlock, ChatMessage } from './core/models/chat.js';
 import { PolicyScreenState } from './core/models/policy-screen-state.js';
 import { ProviderConfig, ProviderPreset } from './core/models/provider-config.js';
@@ -1902,6 +1902,7 @@ export class ProvidersScreen {
 })
 export class PolicyScreen {
   private readonly state = new PolicyScreenState(MOCK_POLICIES);
+  private readonly presentation = new PolicyPresentation();
   public readonly policies = this.state.policies;
   public readonly selectedPolicyId = this.state.selectedPolicyId;
   public readonly draftPolicy = this.state.draftPolicy;
@@ -1957,11 +1958,11 @@ export class PolicyScreen {
   }
 
   public getPolicyStatusBadge(status: Policy['status']): BadgeStatus {
-    return getPolicyStatusBadge(status);
+    return this.presentation.getPolicyStatusBadge(status);
   }
 
   public getRiskColor(riskLevel: Policy['riskLevel']): string {
-    return getRiskColor(riskLevel);
+    return this.presentation.getRiskColor(riskLevel);
   }
 
   private readInputValue(event: Event): string {

--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -14,6 +14,7 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { UiBadgeComponent, BadgeStatus } from './ui/badge.component.js';
 import { UiIconComponent } from './ui/icon.component.js';
 import { MOCK_AGENTS, MOCK_RUNS, MOCK_TOOLS, MOCK_POLICIES, Agent, Run, Tool, Policy } from './ui/mock-data.js';
+import { PolicyPresentation } from './ui/policy-helpers.js';
 import { ChatBlock, ChatMessage } from './core/models/chat.js';
 import { PolicyScreenState } from './core/models/policy-screen-state.js';
 import { ProviderConfig, ProviderPreset } from './core/models/provider-config.js';
@@ -1901,6 +1902,7 @@ export class ProvidersScreen {
 })
 export class PolicyScreen {
   private readonly state = new PolicyScreenState(MOCK_POLICIES);
+  private readonly presentation = new PolicyPresentation();
   public readonly policies = this.state.policies;
   public readonly selectedPolicyId = this.state.selectedPolicyId;
   public readonly draftPolicy = this.state.draftPolicy;
@@ -1956,17 +1958,11 @@ export class PolicyScreen {
   }
 
   public getPolicyStatusBadge(status: Policy['status']): BadgeStatus {
-    return status === 'active' ? 'active' : 'idle';
+    return this.presentation.getPolicyStatusBadge(status);
   }
 
   public getRiskColor(riskLevel: Policy['riskLevel']): string {
-    switch (riskLevel) {
-      case 'Critical': return 'text-red-400';
-      case 'High': return 'text-amber-400';
-      case 'Medium': return 'text-blue-400';
-      case 'Low': return 'text-emerald-400';
-      default: return 'text-zinc-400';
-    }
+    return this.presentation.getRiskColor(riskLevel);
   }
 
   private readInputValue(event: Event): string {

--- a/apps/magnetar-ui/src/app/app.component.ts
+++ b/apps/magnetar-ui/src/app/app.component.ts
@@ -14,6 +14,7 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { UiBadgeComponent, BadgeStatus } from './ui/badge.component.js';
 import { UiIconComponent } from './ui/icon.component.js';
 import { MOCK_AGENTS, MOCK_RUNS, MOCK_TOOLS, MOCK_POLICIES, Agent, Run, Tool, Policy } from './ui/mock-data.js';
+import { getPolicyStatusBadge, getRiskColor } from './ui/policy-helpers.js';
 import { ChatBlock, ChatMessage } from './core/models/chat.js';
 import { PolicyScreenState } from './core/models/policy-screen-state.js';
 import { ProviderConfig, ProviderPreset } from './core/models/provider-config.js';
@@ -1956,17 +1957,11 @@ export class PolicyScreen {
   }
 
   public getPolicyStatusBadge(status: Policy['status']): BadgeStatus {
-    return status === 'active' ? 'active' : 'idle';
+    return getPolicyStatusBadge(status);
   }
 
   public getRiskColor(riskLevel: Policy['riskLevel']): string {
-    switch (riskLevel) {
-      case 'Critical': return 'text-red-400';
-      case 'High': return 'text-amber-400';
-      case 'Medium': return 'text-blue-400';
-      case 'Low': return 'text-emerald-400';
-      default: return 'text-zinc-400';
-    }
+    return getRiskColor(riskLevel);
   }
 
   private readInputValue(event: Event): string {

--- a/apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
+++ b/apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
@@ -1,0 +1,101 @@
+import { computed, signal } from '@angular/core';
+
+import { Policy } from '../../ui/mock-data.js';
+
+export class PolicyScreenState {
+  public readonly policies;
+  public readonly selectedPolicyId = signal<string | null>(null);
+  public readonly draftPolicy = signal<Policy | null>(null);
+  public readonly selectedPolicy;
+  public readonly hasUnsavedChanges;
+
+  public constructor(policies: Policy[]) {
+    this.policies = signal<Policy[]>(policies.map((policy) => this.clonePolicy(policy)));
+    this.selectedPolicy = computed(() => {
+      const selectedPolicyId = this.selectedPolicyId();
+      if (!selectedPolicyId) {
+        return null;
+      }
+
+      return this.policies().find((policy) => policy.id === selectedPolicyId) ?? null;
+    });
+    this.hasUnsavedChanges = computed(() => {
+      const selectedPolicy = this.selectedPolicy();
+      const draftPolicy = this.draftPolicy();
+      if (!selectedPolicy || !draftPolicy) {
+        return false;
+      }
+
+      return (
+        selectedPolicy.name !== draftPolicy.name ||
+        selectedPolicy.description !== draftPolicy.description ||
+        selectedPolicy.riskLevel !== draftPolicy.riskLevel ||
+        selectedPolicy.action !== draftPolicy.action
+      );
+    });
+  }
+
+  public selectPolicy(policyId: string): void {
+    const policy = this.policies().find((candidate) => candidate.id === policyId);
+    if (!policy) {
+      return;
+    }
+
+    this.selectedPolicyId.set(policy.id);
+    this.draftPolicy.set(this.clonePolicy(policy));
+  }
+
+  public closeDetails(): void {
+    this.selectedPolicyId.set(null);
+    this.draftPolicy.set(null);
+  }
+
+  public updateDraftName(name: string): void {
+    this.patchDraft({ name });
+  }
+
+  public updateDraftDescription(description: string): void {
+    this.patchDraft({ description });
+  }
+
+  public updateDraftRiskLevel(riskLevel: Policy['riskLevel']): void {
+    this.patchDraft({ riskLevel });
+  }
+
+  public updateDraftAction(action: Policy['action']): void {
+    this.patchDraft({ action });
+  }
+
+  public saveChanges(): void {
+    const selectedPolicy = this.selectedPolicy();
+    const draftPolicy = this.draftPolicy();
+    if (!selectedPolicy || !draftPolicy) {
+      return;
+    }
+
+    this.policies.update((policies) =>
+      policies.map((policy) => (policy.id === selectedPolicy.id ? this.clonePolicy(draftPolicy) : policy)),
+    );
+    this.draftPolicy.set(this.clonePolicy(draftPolicy));
+  }
+
+  public cancelChanges(): void {
+    const selectedPolicy = this.selectedPolicy();
+    if (!selectedPolicy) {
+      return;
+    }
+
+    this.draftPolicy.set(this.clonePolicy(selectedPolicy));
+  }
+
+  private patchDraft(patch: Partial<Policy>): void {
+    this.draftPolicy.update((draftPolicy) => (draftPolicy ? { ...draftPolicy, ...patch } : draftPolicy));
+  }
+
+  private clonePolicy(policy: Policy): Policy {
+    return {
+      ...policy,
+      tags: [...policy.tags],
+    };
+  }
+}

--- a/apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
+++ b/apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
@@ -1,13 +1,13 @@
-import { computed, signal } from '@angular/core';
+import { computed, signal, type Signal, type WritableSignal } from '@angular/core';
 
 import { Policy } from '../../ui/mock-data.js';
 
 export class PolicyScreenState {
-  public readonly policies;
-  public readonly selectedPolicyId = signal<string | null>(null);
-  public readonly draftPolicy = signal<Policy | null>(null);
-  public readonly selectedPolicy;
-  public readonly hasUnsavedChanges;
+  public readonly policies: WritableSignal<Policy[]>;
+  public readonly selectedPolicyId: WritableSignal<string | null> = signal<string | null>(null);
+  public readonly draftPolicy: WritableSignal<Policy | null> = signal<Policy | null>(null);
+  public readonly selectedPolicy: Signal<Policy | null>;
+  public readonly hasUnsavedChanges: Signal<boolean>;
 
   public constructor(policies: Policy[]) {
     this.policies = signal<Policy[]>(policies.map((policy) => this.clonePolicy(policy)));
@@ -36,6 +36,10 @@ export class PolicyScreenState {
   }
 
   public selectPolicy(policyId: string): void {
+    if (this.selectedPolicyId() === policyId) {
+      return;
+    }
+
     const policy = this.policies().find((candidate) => candidate.id === policyId);
     if (!policy) {
       return;

--- a/apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
+++ b/apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
@@ -1,0 +1,105 @@
+import { computed, signal, type Signal, type WritableSignal } from '@angular/core';
+
+import { Policy } from '../../ui/mock-data.js';
+
+export class PolicyScreenState {
+  public readonly policies: WritableSignal<Policy[]>;
+  public readonly selectedPolicyId: WritableSignal<string | null> = signal<string | null>(null);
+  public readonly draftPolicy: WritableSignal<Policy | null> = signal<Policy | null>(null);
+  public readonly selectedPolicy: Signal<Policy | null>;
+  public readonly hasUnsavedChanges: Signal<boolean>;
+
+  public constructor(policies: Policy[]) {
+    this.policies = signal<Policy[]>(policies.map((policy) => this.clonePolicy(policy)));
+    this.selectedPolicy = computed(() => {
+      const selectedPolicyId = this.selectedPolicyId();
+      if (!selectedPolicyId) {
+        return null;
+      }
+
+      return this.policies().find((policy) => policy.id === selectedPolicyId) ?? null;
+    });
+    this.hasUnsavedChanges = computed(() => {
+      const selectedPolicy = this.selectedPolicy();
+      const draftPolicy = this.draftPolicy();
+      if (!selectedPolicy || !draftPolicy) {
+        return false;
+      }
+
+      return (
+        selectedPolicy.name !== draftPolicy.name ||
+        selectedPolicy.description !== draftPolicy.description ||
+        selectedPolicy.riskLevel !== draftPolicy.riskLevel ||
+        selectedPolicy.action !== draftPolicy.action
+      );
+    });
+  }
+
+  public selectPolicy(policyId: string): void {
+    if (this.selectedPolicyId() === policyId) {
+      return;
+    }
+
+    const policy = this.policies().find((candidate) => candidate.id === policyId);
+    if (!policy) {
+      return;
+    }
+
+    this.selectedPolicyId.set(policy.id);
+    this.draftPolicy.set(this.clonePolicy(policy));
+  }
+
+  public closeDetails(): void {
+    this.selectedPolicyId.set(null);
+    this.draftPolicy.set(null);
+  }
+
+  public updateDraftName(name: string): void {
+    this.patchDraft({ name });
+  }
+
+  public updateDraftDescription(description: string): void {
+    this.patchDraft({ description });
+  }
+
+  public updateDraftRiskLevel(riskLevel: Policy['riskLevel']): void {
+    this.patchDraft({ riskLevel });
+  }
+
+  public updateDraftAction(action: Policy['action']): void {
+    this.patchDraft({ action });
+  }
+
+  public saveChanges(): void {
+    const selectedPolicy = this.selectedPolicy();
+    const draftPolicy = this.draftPolicy();
+    if (!selectedPolicy || !draftPolicy) {
+      return;
+    }
+
+    this.policies.update((policies) =>
+      policies.map((policy) => (policy.id === selectedPolicy.id ? this.clonePolicy(draftPolicy) : policy)),
+    );
+    this.draftPolicy.set(this.clonePolicy(draftPolicy));
+  }
+
+  public cancelChanges(): void {
+    const selectedPolicy = this.selectedPolicy();
+    if (!selectedPolicy) {
+      return;
+    }
+
+    this.draftPolicy.set(this.clonePolicy(selectedPolicy));
+  }
+
+  private patchDraft(patch: Partial<Policy>): void {
+    this.draftPolicy.update((draftPolicy) => (draftPolicy ? { ...draftPolicy, ...patch } : draftPolicy));
+  }
+
+  private clonePolicy(policy: Policy): Policy {
+    return {
+      ...policy,
+      tags: [...policy.tags],
+    };
+  }
+}

--- a/apps/magnetar-ui/src/app/ui/icons.ts
+++ b/apps/magnetar-ui/src/app/ui/icons.ts
@@ -45,4 +45,7 @@ export const ICONS: Record<string, string> = {
   battery: 'M20 10V8a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2 M20 14h2 M22 10v4',
   'pie-chart': 'M21.21 15.89A10 10 0 1 1 8 2.83 M22 12A10 10 0 0 0 12 2v10z',
   bell: 'M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9 M13.73 21a2 2 0 0 1-3.46 0',
+  'file-minus':
+    'M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z M14 2v6h6 M9 15h6',
+  layers: 'M12 2L2 7l10 5 10-5-10-5z M2 17l10 5 10-5 M2 12l10 5 10-5',
 };

--- a/apps/magnetar-ui/src/app/ui/policy-helpers.ts
+++ b/apps/magnetar-ui/src/app/ui/policy-helpers.ts
@@ -1,0 +1,21 @@
+import type { BadgeStatus } from './badge.component.js';
+import type { Policy, PolicyRiskLevel } from './mock-data.js';
+
+export function getPolicyStatusBadge(status: Policy['status']): BadgeStatus {
+  return status === 'active' ? 'active' : 'idle';
+}
+
+export function getRiskColor(riskLevel: PolicyRiskLevel): string {
+  switch (riskLevel) {
+    case 'Critical':
+      return 'text-red-400';
+    case 'High':
+      return 'text-amber-400';
+    case 'Medium':
+      return 'text-blue-400';
+    case 'Low':
+      return 'text-emerald-400';
+    default:
+      return 'text-zinc-400';
+  }
+}

--- a/apps/magnetar-ui/src/app/ui/policy-helpers.ts
+++ b/apps/magnetar-ui/src/app/ui/policy-helpers.ts
@@ -1,0 +1,23 @@
+import type { BadgeStatus } from './badge.component.js';
+import type { Policy, PolicyRiskLevel } from './mock-data.js';
+
+export class PolicyPresentation {
+  public getPolicyStatusBadge(status: Policy['status']): BadgeStatus {
+    return status === 'active' ? 'active' : 'idle';
+  }
+
+  public getRiskColor(riskLevel: PolicyRiskLevel): string {
+    switch (riskLevel) {
+      case 'Critical':
+        return 'text-red-400';
+      case 'High':
+        return 'text-amber-400';
+      case 'Medium':
+        return 'text-blue-400';
+      case 'Low':
+        return 'text-emerald-400';
+      default:
+        return 'text-zinc-400';
+    }
+  }
+}

--- a/apps/magnetar-ui/src/app/ui/policy-helpers.ts
+++ b/apps/magnetar-ui/src/app/ui/policy-helpers.ts
@@ -1,21 +1,23 @@
 import type { BadgeStatus } from './badge.component.js';
 import type { Policy, PolicyRiskLevel } from './mock-data.js';
 
-export function getPolicyStatusBadge(status: Policy['status']): BadgeStatus {
-  return status === 'active' ? 'active' : 'idle';
-}
+export class PolicyPresentation {
+  public getPolicyStatusBadge(status: Policy['status']): BadgeStatus {
+    return status === 'active' ? 'active' : 'idle';
+  }
 
-export function getRiskColor(riskLevel: PolicyRiskLevel): string {
-  switch (riskLevel) {
-    case 'Critical':
-      return 'text-red-400';
-    case 'High':
-      return 'text-amber-400';
-    case 'Medium':
-      return 'text-blue-400';
-    case 'Low':
-      return 'text-emerald-400';
-    default:
-      return 'text-zinc-400';
+  public getRiskColor(riskLevel: PolicyRiskLevel): string {
+    switch (riskLevel) {
+      case 'Critical':
+        return 'text-red-400';
+      case 'High':
+        return 'text-amber-400';
+      case 'Medium':
+        return 'text-blue-400';
+      case 'Low':
+        return 'text-emerald-400';
+      default:
+        return 'text-zinc-400';
+    }
   }
 }

--- a/apps/magnetar-ui/tests/policy-helpers.spec.ts
+++ b/apps/magnetar-ui/tests/policy-helpers.spec.ts
@@ -1,29 +1,29 @@
 import { describe, expect, it } from 'vitest';
 
-import { getPolicyStatusBadge, getRiskColor } from '../src/app/ui/policy-helpers.js';
+import { PolicyPresentation } from '../src/app/ui/policy-helpers.js';
 import type { PolicyRiskLevel } from '../src/app/ui/mock-data.js';
 
-describe('getPolicyStatusBadge', () => {
+describe('PolicyPresentation', () => {
+  const presentation = new PolicyPresentation();
+
   it('maps an active policy status to the active badge variant', () => {
-    expect(getPolicyStatusBadge('active')).toBe('active');
+    expect(presentation.getPolicyStatusBadge('active')).toBe('active');
   });
 
   it('maps a disabled policy status to the idle badge variant', () => {
-    expect(getPolicyStatusBadge('disabled')).toBe('idle');
+    expect(presentation.getPolicyStatusBadge('disabled')).toBe('idle');
   });
-});
 
-describe('getRiskColor', () => {
   it.each<[PolicyRiskLevel, string]>([
     ['Critical', 'text-red-400'],
     ['High', 'text-amber-400'],
     ['Medium', 'text-blue-400'],
     ['Low', 'text-emerald-400'],
   ])('maps %s risk level to CSS class %s', (riskLevel, expected) => {
-    expect(getRiskColor(riskLevel)).toBe(expected);
+    expect(presentation.getRiskColor(riskLevel)).toBe(expected);
   });
 
   it('returns the zinc fallback class for an unrecognised risk level', () => {
-    expect(getRiskColor('Unknown' as PolicyRiskLevel)).toBe('text-zinc-400');
+    expect(presentation.getRiskColor('Unknown' as PolicyRiskLevel)).toBe('text-zinc-400');
   });
 });

--- a/apps/magnetar-ui/tests/policy-helpers.spec.ts
+++ b/apps/magnetar-ui/tests/policy-helpers.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPolicyStatusBadge, getRiskColor } from '../src/app/ui/policy-helpers.js';
+import type { PolicyRiskLevel } from '../src/app/ui/mock-data.js';
+
+describe('getPolicyStatusBadge', () => {
+  it('maps an active policy status to the active badge variant', () => {
+    expect(getPolicyStatusBadge('active')).toBe('active');
+  });
+
+  it('maps a disabled policy status to the idle badge variant', () => {
+    expect(getPolicyStatusBadge('disabled')).toBe('idle');
+  });
+});
+
+describe('getRiskColor', () => {
+  it.each<[PolicyRiskLevel, string]>([
+    ['Critical', 'text-red-400'],
+    ['High', 'text-amber-400'],
+    ['Medium', 'text-blue-400'],
+    ['Low', 'text-emerald-400'],
+  ])('maps %s risk level to CSS class %s', (riskLevel, expected) => {
+    expect(getRiskColor(riskLevel)).toBe(expected);
+  });
+
+  it('returns the zinc fallback class for an unrecognised risk level', () => {
+    expect(getRiskColor('Unknown' as PolicyRiskLevel)).toBe('text-zinc-400');
+  });
+});

--- a/apps/magnetar-ui/tests/policy-helpers.spec.ts
+++ b/apps/magnetar-ui/tests/policy-helpers.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { PolicyPresentation } from '../src/app/ui/policy-helpers.js';
+import type { PolicyRiskLevel } from '../src/app/ui/mock-data.js';
+
+describe('PolicyPresentation', () => {
+  const presentation = new PolicyPresentation();
+
+  it('maps an active policy status to the active badge variant', () => {
+    expect(presentation.getPolicyStatusBadge('active')).toBe('active');
+  });
+
+  it('maps a disabled policy status to the idle badge variant', () => {
+    expect(presentation.getPolicyStatusBadge('disabled')).toBe('idle');
+  });
+
+  it.each<[PolicyRiskLevel, string]>([
+    ['Critical', 'text-red-400'],
+    ['High', 'text-amber-400'],
+    ['Medium', 'text-blue-400'],
+    ['Low', 'text-emerald-400'],
+  ])('maps %s risk level to CSS class %s', (riskLevel, expected) => {
+    expect(presentation.getRiskColor(riskLevel)).toBe(expected);
+  });
+
+  it('returns the zinc fallback class for an unrecognised risk level', () => {
+    expect(presentation.getRiskColor('Unknown' as PolicyRiskLevel)).toBe('text-zinc-400');
+  });
+});

--- a/apps/magnetar-ui/tests/policy-screen.spec.ts
+++ b/apps/magnetar-ui/tests/policy-screen.spec.ts
@@ -68,6 +68,19 @@ describe('PolicyScreen', () => {
     expect(screen.hasUnsavedChanges()).toBe(false);
   });
 
+  it('preserves unsaved draft changes when the already-selected policy is clicked again', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-03');
+    screen.updateDraftDescription('Unsaved draft description');
+
+    screen.selectPolicy('pol-03');
+
+    expect(screen.selectedPolicy()?.description).toBe('Any outbound network call to untrusted domains is strictly blocked.');
+    expect(screen.draftPolicy()?.description).toBe('Unsaved draft description');
+    expect(screen.hasUnsavedChanges()).toBe(true);
+  });
+
   it('clears the detail panel state when closed', () => {
     const screen = new PolicyScreenState(MOCK_POLICIES);
 

--- a/apps/magnetar-ui/tests/policy-screen.spec.ts
+++ b/apps/magnetar-ui/tests/policy-screen.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { PolicyScreenState } from '../src/app/core/models/policy-screen-state.js';
+import { MOCK_POLICIES } from '../src/app/ui/mock-data.js';
+
+describe('PolicyScreen', () => {
+  it('creates a draft copy when selecting a policy without mutating the source state', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-01');
+
+    expect(screen.selectedPolicy()?.id).toBe('pol-01');
+    expect(screen.draftPolicy()).toMatchObject({
+      id: 'pol-01',
+      name: 'Prevent File Deletion',
+    });
+
+    screen.updateDraftName('Prevent Production File Deletion');
+
+    expect(screen.draftPolicy()?.name).toBe('Prevent Production File Deletion');
+    expect(screen.selectedPolicy()?.name).toBe('Prevent File Deletion');
+    expect(screen.hasUnsavedChanges()).toBe(true);
+  });
+
+  it('commits draft updates back into the local policy collection on save', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-02');
+    screen.updateDraftDescription('SELECT-only queries remain auto-approved in the local PoC.');
+    screen.updateDraftAction('Require Review');
+
+    screen.saveChanges();
+
+    expect(screen.selectedPolicy()).toMatchObject({
+      id: 'pol-02',
+      description: 'SELECT-only queries remain auto-approved in the local PoC.',
+      action: 'Require Review',
+    });
+    expect(screen.draftPolicy()).toMatchObject({
+      id: 'pol-02',
+      description: 'SELECT-only queries remain auto-approved in the local PoC.',
+      action: 'Require Review',
+    });
+    expect(screen.hasUnsavedChanges()).toBe(false);
+  });
+
+  it('restores the original selected policy values on cancel', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-03');
+    screen.updateDraftRiskLevel('Critical');
+    screen.updateDraftAction('Simulate');
+
+    expect(screen.hasUnsavedChanges()).toBe(true);
+
+    screen.cancelChanges();
+
+    expect(screen.draftPolicy()).toMatchObject({
+      id: 'pol-03',
+      riskLevel: 'High',
+      action: 'Block',
+    });
+    expect(screen.selectedPolicy()).toMatchObject({
+      id: 'pol-03',
+      riskLevel: 'High',
+      action: 'Block',
+    });
+    expect(screen.hasUnsavedChanges()).toBe(false);
+  });
+
+  it('clears the detail panel state when closed', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-04');
+    screen.closeDetails();
+
+    expect(screen.selectedPolicy()).toBeNull();
+    expect(screen.draftPolicy()).toBeNull();
+    expect(screen.selectedPolicyId()).toBeNull();
+  });
+
+  it('keeps state unchanged when selection or edit actions are invoked without a valid selected policy', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+    const originalPolicies = screen.policies();
+
+    expect(screen.hasUnsavedChanges()).toBe(false);
+
+    screen.selectPolicy('missing-policy');
+    screen.updateDraftName('No-op name');
+    screen.updateDraftDescription('No-op description');
+    screen.updateDraftRiskLevel('Critical');
+    screen.updateDraftAction('Block');
+    screen.saveChanges();
+    screen.cancelChanges();
+
+    expect(screen.selectedPolicy()).toBeNull();
+    expect(screen.draftPolicy()).toBeNull();
+    expect(screen.selectedPolicyId()).toBeNull();
+    expect(screen.hasUnsavedChanges()).toBe(false);
+    expect(screen.policies()).toEqual(originalPolicies);
+  });
+
+  it('treats a stale selected policy id as no active selection', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectedPolicyId.set('stale-policy-id');
+
+    expect(screen.selectedPolicy()).toBeNull();
+    expect(screen.hasUnsavedChanges()).toBe(false);
+  });
+});

--- a/apps/magnetar-ui/tests/policy-screen.spec.ts
+++ b/apps/magnetar-ui/tests/policy-screen.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { PolicyScreenState } from '../src/app/core/models/policy-screen-state.js';
+import { MOCK_POLICIES } from '../src/app/ui/mock-data.js';
+
+describe('PolicyScreen', () => {
+  it('creates a draft copy when selecting a policy without mutating the source state', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-01');
+
+    expect(screen.selectedPolicy()?.id).toBe('pol-01');
+    expect(screen.draftPolicy()).toMatchObject({
+      id: 'pol-01',
+      name: 'Prevent File Deletion',
+    });
+
+    screen.updateDraftName('Prevent Production File Deletion');
+
+    expect(screen.draftPolicy()?.name).toBe('Prevent Production File Deletion');
+    expect(screen.selectedPolicy()?.name).toBe('Prevent File Deletion');
+    expect(screen.hasUnsavedChanges()).toBe(true);
+  });
+
+  it('commits draft updates back into the local policy collection on save', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-02');
+    screen.updateDraftDescription('SELECT-only queries remain auto-approved in the local PoC.');
+    screen.updateDraftAction('Require Review');
+
+    screen.saveChanges();
+
+    expect(screen.selectedPolicy()).toMatchObject({
+      id: 'pol-02',
+      description: 'SELECT-only queries remain auto-approved in the local PoC.',
+      action: 'Require Review',
+    });
+    expect(screen.draftPolicy()).toMatchObject({
+      id: 'pol-02',
+      description: 'SELECT-only queries remain auto-approved in the local PoC.',
+      action: 'Require Review',
+    });
+    expect(screen.hasUnsavedChanges()).toBe(false);
+  });
+
+  it('restores the original selected policy values on cancel', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-03');
+    screen.updateDraftRiskLevel('Critical');
+    screen.updateDraftAction('Simulate');
+
+    expect(screen.hasUnsavedChanges()).toBe(true);
+
+    screen.cancelChanges();
+
+    expect(screen.draftPolicy()).toMatchObject({
+      id: 'pol-03',
+      riskLevel: 'High',
+      action: 'Block',
+    });
+    expect(screen.selectedPolicy()).toMatchObject({
+      id: 'pol-03',
+      riskLevel: 'High',
+      action: 'Block',
+    });
+    expect(screen.hasUnsavedChanges()).toBe(false);
+  });
+
+  it('preserves unsaved draft changes when the already-selected policy is clicked again', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-03');
+    screen.updateDraftDescription('Unsaved draft description');
+
+    screen.selectPolicy('pol-03');
+
+    expect(screen.selectedPolicy()?.description).toBe('Any outbound network call to untrusted domains is strictly blocked.');
+    expect(screen.draftPolicy()?.description).toBe('Unsaved draft description');
+    expect(screen.hasUnsavedChanges()).toBe(true);
+  });
+
+  it('clears the detail panel state when closed', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectPolicy('pol-04');
+    screen.closeDetails();
+
+    expect(screen.selectedPolicy()).toBeNull();
+    expect(screen.draftPolicy()).toBeNull();
+    expect(screen.selectedPolicyId()).toBeNull();
+  });
+
+  it('keeps state unchanged when selection or edit actions are invoked without a valid selected policy', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+    const originalPolicies = screen.policies();
+
+    expect(screen.hasUnsavedChanges()).toBe(false);
+
+    screen.selectPolicy('missing-policy');
+    screen.updateDraftName('No-op name');
+    screen.updateDraftDescription('No-op description');
+    screen.updateDraftRiskLevel('Critical');
+    screen.updateDraftAction('Block');
+    screen.saveChanges();
+    screen.cancelChanges();
+
+    expect(screen.selectedPolicy()).toBeNull();
+    expect(screen.draftPolicy()).toBeNull();
+    expect(screen.selectedPolicyId()).toBeNull();
+    expect(screen.hasUnsavedChanges()).toBe(false);
+    expect(screen.policies()).toEqual(originalPolicies);
+  });
+
+  it('treats a stale selected policy id as no active selection', () => {
+    const screen = new PolicyScreenState(MOCK_POLICIES);
+
+    screen.selectedPolicyId.set('stale-policy-id');
+
+    expect(screen.selectedPolicy()).toBeNull();
+    expect(screen.hasUnsavedChanges()).toBe(false);
+  });
+});

--- a/apps/magnetar-ui/tests/ui-data.spec.ts
+++ b/apps/magnetar-ui/tests/ui-data.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { ICONS } from '../src/app/ui/icons.js';
-import { MOCK_AGENTS, MOCK_RUNS, MOCK_TOOLS } from '../src/app/ui/mock-data.js';
+import { MOCK_AGENTS, MOCK_RUNS, MOCK_TOOLS, MOCK_POLICIES } from '../src/app/ui/mock-data.js';
 
 describe('UI mock data', () => {
   it('exposes representative agents, runs, and tools for the shell screens', () => {
@@ -30,6 +30,35 @@ describe('UI mock data', () => {
       expect(ICONS[tool.icon].length).toBeGreaterThan(0);
     }
   });
+
+  it('exposes policies covering all risk levels, actions, and statuses', () => {
+    expect(MOCK_POLICIES).toHaveLength(6);
+    expect(new Set(MOCK_POLICIES.map((p) => p.riskLevel))).toEqual(
+      new Set(['Low', 'High', 'Critical']),
+    );
+    expect(new Set(MOCK_POLICIES.map((p) => p.action))).toEqual(
+      new Set(['Auto-Approve', 'Require Review', 'Block', 'Simulate']),
+    );
+    expect(new Set(MOCK_POLICIES.map((p) => p.status))).toEqual(
+      new Set(['active', 'disabled']),
+    );
+  });
+
+  it('ensures every policy has a unique id, a non-empty name, and at least one tag', () => {
+    const ids = MOCK_POLICIES.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const policy of MOCK_POLICIES) {
+      expect(policy.name.length).toBeGreaterThan(0);
+      expect(policy.tags.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('maps every mock policy icon to a registered icon glyph', () => {
+    for (const policy of MOCK_POLICIES) {
+      expect(ICONS[policy.icon]).toBeTypeOf('string');
+      expect(ICONS[policy.icon].length).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe('ICONS registry', () => {
@@ -43,5 +72,7 @@ describe('ICONS registry', () => {
     expect(ICONS['file-text']).toBeTypeOf('string');
     expect(ICONS.zap).toBeTypeOf('string');
     expect(ICONS.bell).toBeTypeOf('string');
+    expect(ICONS['file-minus']).toBeTypeOf('string');
+    expect(ICONS.layers).toBeTypeOf('string');
   });
 });

--- a/branches/fix-policy-center-explicit-placeholders-255/CHANGES.md
+++ b/branches/fix-policy-center-explicit-placeholders-255/CHANGES.md
@@ -1,0 +1,9 @@
+# Changes for fix/policy-center-explicit-placeholders-255
+
+## Summary
+Solve issue `#255` by making the remaining Policy Center dead-end actions explicit placeholders instead of presenting them as active governance flows.
+
+## Changes
+- Disabled the `Audit Logs` and `Create Policy` header actions in the Policy Center PoC.
+- Relabeled those actions as planned follow-up work and added explanatory tooltip text.
+- Added a visible PoC-boundary note clarifying that local policy inspection/editing is active while audit-log navigation and policy creation are still planned.

--- a/branches/fix-policy-screen-real-state-254/CHANGES.md
+++ b/branches/fix-policy-screen-real-state-254/CHANGES.md
@@ -1,0 +1,10 @@
+# Changes for fix/policy-screen-real-state-254
+
+## Summary
+Solve issue `#254` by making the Policy Center detail panel truthful and locally interactive instead of presenting fake editing controls.
+
+## Changes
+- Reworked `PolicyScreen` to manage local policy state, selection state, and draft editing state explicitly.
+- Wired the detail panel inputs and selects to real draft-update handlers.
+- Made `Save Changes`, `Cancel`, and close behavior operate on real local draft state.
+- Added focused tests that cover policy selection, draft editing, save behavior, cancel behavior, and detail-panel reset behavior.


### PR DESCRIPTION
### **User description**
## Summary
- integrate the follow-up fixes from review/pr-250 back into the original Policy Center PoC branch
- bring in the resolved review gaps for real local edit state, truthful placeholder actions, and automated coverage
- keep PR #250 as the final feature branch merge target once this integration PR lands

## Included Follow-up Work
- #254 via PR #257: real local draft/edit state for the Policy Center detail panel
- #255 via PR #258: explicit planned placeholders for dead-end actions and PoC scope messaging
- #256 via PR #260: automated coverage, icon registry fixes, and policy presentation extraction

## Validation
- npm --prefix apps/magnetar-ui run typecheck
- npm --prefix apps/magnetar-ui run test:ci
- npm run validate:required-docs


___

### **Description**
- Enhanced the Policy Center to support real local editing and state management.
- Introduced `PolicyScreenState` for managing policy selection and draft editing.
- Added `PolicyPresentation` for handling visual representation of policy statuses.
- Implemented comprehensive tests for new state management and presentation logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.component.ts</strong><dd><code>Enhance Policy Center with Real State Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/magnetar-ui/src/app/app.component.ts
<li>Integrated <code>PolicyScreenState</code> and <code>PolicyPresentation</code> for better state <br>management.<br> <li> Updated UI components to reflect real local editing capabilities.<br> <li> Added planned follow-up indicators for certain actions.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/262/files#diff-98cd05c775278d9d124e85dfbb98bf94f9bb01c0ea490ee52abea54a14485673">+119/-34</a></td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>policy-screen-state.ts</strong><dd><code>Implement Policy Screen State Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/magnetar-ui/src/app/core/models/policy-screen-state.ts
<li>Created <code>PolicyScreenState</code> class to manage policy selection and draft <br>editing.<br> <li> Implemented computed properties for selected policy and unsaved <br>changes.<br> <li> Added methods for updating draft policy attributes.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/262/files#diff-f72e72f02bfb12a328c0d112fe6f012f86372f7de8356e21ce26a24c19ec8f7c">+105/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>policy-helpers.ts</strong><dd><code>Add Policy Presentation Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/magnetar-ui/src/app/ui/policy-helpers.ts
<li>Introduced <code>PolicyPresentation</code> class for handling policy status and <br>risk color.<br> <li> Encapsulated logic for badge status and risk level representation.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/262/files#diff-7c58b72a7165d006c8529457bfbf11d9d41dd8afa762a8beda4008070d05fb4f">+23/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>policy-helpers.spec.ts</strong><dd><code>Test Policy Presentation Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/magnetar-ui/tests/policy-helpers.spec.ts
<li>Added tests for <code>PolicyPresentation</code> methods.<br> <li> Verified mappings for policy status and risk levels.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/262/files#diff-93e74693340cb3c38c04aa6ccac14496ecd7363d32a89d75e47f88295255188e">+29/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>policy-screen.spec.ts</strong><dd><code>Test Policy Screen State Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/magnetar-ui/tests/policy-screen.spec.ts
<li>Added tests for <code>PolicyScreenState</code> functionality.<br> <li> Covered policy selection, draft updates, and state management <br>behaviors.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/262/files#diff-ecbd7edeffdc381d8817ca48dea285dd19357fca3439700de6967b5793c09fbd">+124/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ui-data.spec.ts</strong><dd><code>Validate Mock Policy Data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/magnetar-ui/tests/ui-data.spec.ts
<li>Expanded tests to cover mock policy data integrity.<br> <li> Ensured unique IDs and valid attributes for policies.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarEidolon/pull/262/files#diff-061214a3179046acb439c61bd2ecfae07a4f00a32491a92569e34b7f556f3297">+32/-1</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

