### PR TITLE
[task-ts-qa-102] Implement deterministic Faker factories for TypeScript tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -37,6 +37,10 @@ The TypeScript implementation of the Magnetar SDK must adhere to the highest qua
     - **Focus**: Pure functions, state models, and individual agent logic steps.
     - **Tooling**: `Vitest`.
     - **Data Strategy**: Use `@faker-js/faker` to generate realistic, diverse, and unexpected data payloads. Mocking must be granular and modular.
+    - **Shared Factory Location**: Core runtime generated fixtures live in `packages/magnetar-sdk/tests/factories/`.
+    - **Seed Strategy**: Use `createTestFaker(deriveTestSeed('<suite-or-scenario-name>'))` so generated data stays reproducible in CI and across local runs.
+    - **Readability Rule**: Prefer generated fixtures for broad state/data combinations and edge cases; keep explicit hand-written fixtures when a test depends on exact strings, exact prompts, or exact rendering output.
+    - **Override Rule**: When using generated fixtures, override the exact fields asserted by the test so the scenario remains easy to understand and debug.
     - **Requirement**: No code in `packages/magnetar-sdk/src/` may be merged without complete coverage for the affected module. While shared code still lives temporarily inside the UI workspace, the same standard applies there.
 
 2.  **Integration Tests**

--- a/packages/magnetar-sdk/package-lock.json
+++ b/packages/magnetar-sdk/package-lock.json
@@ -13,6 +13,7 @@
         "typescript": "^5.6.3"
       },
       "devDependencies": {
+        "@faker-js/faker": "^10.4.0",
         "vitest": "^4.1.1"
       },
       "engines": {
@@ -51,6 +52,23 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {

--- a/packages/magnetar-sdk/package.json
+++ b/packages/magnetar-sdk/package.json
@@ -48,6 +48,7 @@
     "typescript": "^5.6.3"
   },
   "devDependencies": {
+    "@faker-js/faker": "^10.4.0",
     "vitest": "^4.1.1"
   }
 }

--- a/packages/magnetar-sdk/tests/agent.spec.ts
+++ b/packages/magnetar-sdk/tests/agent.spec.ts
@@ -1,36 +1,57 @@
 import { describe, it, expect, vi } from 'vitest';
 import { of } from 'rxjs';
+
 import { MagnetarAgent } from '../src/agent.js';
-import { InMemoryTraceStore } from '../src/providers/in-memory-trace-store.js';
-import { MagnetarEidolon } from '../src/models.js';
 import { LLMProvider, MemoryStore, Tool } from '../src/interfaces.js';
+import { InMemoryTraceStore } from '../src/providers/in-memory-trace-store.js';
+import {
+  createGoal,
+  createMagnetarState,
+  createMemoryItem,
+  createToolResult,
+} from './factories/magnetar-factories.js';
+import { createTestFaker, deriveTestSeed } from './factories/faker.js';
+
+function createTestState(seedNamespace: string, overrides = {}) {
+  const faker = createTestFaker(deriveTestSeed(seedNamespace));
+
+  return createMagnetarState(
+    {
+      agentId: 'test-agent',
+      plan: [],
+      shortTermMemory: [],
+      toolHistory: [],
+      metadata: {},
+      ...overrides,
+    },
+    faker,
+  );
+}
+
+function createMemoryStoreMock(): MemoryStore {
+  return {
+    addMemory: vi.fn().mockReturnValue(of(void 0)),
+    query: vi.fn().mockReturnValue(of([])),
+  };
+}
 
 describe('MagnetarAgent Tracing', () => {
   it('should emit trace events during the step lifecycle', () => {
     return new Promise<void>((resolve, reject) => {
-      const state: MagnetarEidolon = {
-        agentId: 'test-agent',
-        plan: [],
-        shortTermMemory: [],
-        toolHistory: [],
-        metadata: {}
-      };
+      const state = createTestState('agent-tracing-tool-step');
 
       const mockTool: Tool = {
         name: 'testTool',
         description: 'A test tool',
-        execute: vi.fn().mockReturnValue(of({ success: true, output: 'Tool success' }))
+        execute: vi.fn().mockReturnValue(of(createToolResult({ output: 'Tool success' }))),
       };
 
-      const mockMemoryStore: MemoryStore = {
-        addMemory: vi.fn().mockReturnValue(of(void 0)),
-        query: vi.fn().mockReturnValue(of([]))
-      };
+      const mockMemoryStore = createMemoryStoreMock();
 
       const mockLlm: LLMProvider = {
         generate: vi.fn().mockReturnValue(of({
           content: 'TOOL: testTool\nARGS: {"param": "value"}'
-        }))
+        })),
       };
 
       const traceStore = new InMemoryTraceStore();
@@ -72,30 +93,23 @@ describe('MagnetarAgent Tracing', () => {
             reject(e);
           }
         },
-        error: (err) => reject(err)
+        error: (err) => reject(err),
       });
     });
   });
 
   it('should emit finish event on FINAL action', () => {
     return new Promise<void>((resolve, reject) => {
-      const state: MagnetarEidolon = {
-        agentId: 'test-agent',
-        plan: [],
-        shortTermMemory: [],
-        toolHistory: [],
-        metadata: {}
-      };
+      const state = createTestState('agent-tracing-finish-step', {
+        goal: createGoal({ status: 'active' }, createTestFaker(deriveTestSeed('agent-tracing-finish-goal'))),
+      });
 
-      const mockMemoryStore: MemoryStore = {
-        addMemory: vi.fn().mockReturnValue(of(void 0)),
-        query: vi.fn().mockReturnValue(of([]))
-      };
+      const mockMemoryStore = createMemoryStoreMock();
 
       const mockLlm: LLMProvider = {
         generate: vi.fn().mockReturnValue(of({
           content: 'FINAL: Task completed'
-        }))
+        })),
       };
 
       const traceStore = new InMemoryTraceStore();
@@ -109,36 +123,28 @@ describe('MagnetarAgent Tracing', () => {
             const finishEvent = events.find(e => e.type === 'finish');
             expect(finishEvent).toBeDefined();
             expect(finishEvent?.data.message).toBe('Task completed');
+            expect(state.goal?.status).toBe('completed');
 
             resolve();
           } catch (e) {
             reject(e);
           }
         },
-        error: (err) => reject(err)
+        error: (err) => reject(err),
       });
     });
   });
 
   it('should emit an error trace when a tool is not found', () => {
     return new Promise<void>((resolve, reject) => {
-      const state: MagnetarEidolon = {
-        agentId: 'test-agent',
-        plan: [],
-        shortTermMemory: [],
-        toolHistory: [],
-        metadata: {}
-      };
+      const state = createTestState('agent-tracing-missing-tool');
 
-      const mockMemoryStore: MemoryStore = {
-        addMemory: vi.fn().mockReturnValue(of(void 0)),
-        query: vi.fn().mockReturnValue(of([]))
-      };
+      const mockMemoryStore = createMemoryStoreMock();
 
       const mockLlm: LLMProvider = {
         generate: vi.fn().mockReturnValue(of({
           content: 'TOOL: missingTool\nARGS: {}'
-        }))
+        })),
       };
 
       const traceStore = new InMemoryTraceStore();
@@ -159,7 +165,53 @@ describe('MagnetarAgent Tracing', () => {
             reject(e);
           }
         },
-        error: (err) => reject(err)
+        error: (err) => reject(err),
+      });
+    });
+  });
+
+  it('should build prompts from the last five generated memory entries only', () => {
+    return new Promise<void>((resolve, reject) => {
+      const faker = createTestFaker(deriveTestSeed('agent-tracing-history-window'));
+      const history = Array.from({ length: 6 }, (_, index) =>
+        createMemoryItem({ content: `memory-${index}` }, faker),
+      );
+      const state = createMagnetarState(
+        {
+          agentId: 'test-agent',
+          goal: createGoal({ description: 'Inspect history', status: 'active' }, faker),
+          plan: [],
+          shortTermMemory: history,
+          toolHistory: [],
+          metadata: {},
+        },
+        faker,
+      );
+      const mockMemoryStore = createMemoryStoreMock();
+      const mockLlm: LLMProvider = {
+        generate: vi.fn().mockReturnValue(of({
+          content: 'FINAL: History inspected'
+        })),
+      };
+      const traceStore = new InMemoryTraceStore();
+      const agent = new MagnetarAgent(state, [], mockMemoryStore, mockLlm, traceStore);
+
+      agent.step().subscribe({
+        next: () => {
+          try {
+            const prompt = mockLlm.generate.mock.calls[0]?.[0]?.[0]?.content as string;
+
+            expect(prompt).not.toContain('memory-0');
+            expect(prompt).toContain('memory-1');
+            expect(prompt).toContain('memory-5');
+            expect(state.goal?.status).toBe('completed');
+
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        error: (err) => reject(err),
       });
     });
   });

--- a/packages/magnetar-sdk/tests/factories.spec.ts
+++ b/packages/magnetar-sdk/tests/factories.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveTestSeed, createTestFaker } from './factories/faker.js';
+import {
+  createGoal,
+  createMagnetarState,
+  createMemoryItem,
+  createTask,
+  createToolCall,
+  createToolResult,
+} from './factories/magnetar-factories.js';
+
+describe('magnetar faker factories', () => {
+  it('creates reproducible fixtures for the same namespace seed', () => {
+    const seed = deriveTestSeed('sdk-factory-repro');
+    const firstFaker = createTestFaker(seed);
+    const secondFaker = createTestFaker(seed);
+
+    const firstState = createMagnetarState(undefined, firstFaker);
+    const secondState = createMagnetarState(undefined, secondFaker);
+
+    expect(secondState).toEqual(firstState);
+  });
+
+  it('supports deterministic overrides for core runtime models', () => {
+    const faker = createTestFaker(deriveTestSeed('sdk-factory-overrides'));
+
+    const goal = createGoal({ status: 'active' }, faker);
+    const task = createTask({ status: 'in_progress' }, faker);
+    const memory = createMemoryItem({ metadata: { source: 'manual' } }, faker);
+    const toolCall = createToolCall({ toolName: 'search' }, faker);
+    const result = createToolResult({ success: false, error: 'search failed' }, faker);
+
+    expect(goal.status).toBe('active');
+    expect(task.status).toBe('in_progress');
+    expect(memory.metadata).toEqual({ source: 'manual' });
+    expect(toolCall.toolName).toBe('search');
+    expect(result).toEqual({
+      success: false,
+      output: expect.any(String),
+      error: 'search failed',
+    });
+  });
+});

--- a/packages/magnetar-sdk/tests/factories/faker.ts
+++ b/packages/magnetar-sdk/tests/factories/faker.ts
@@ -1,0 +1,21 @@
+import { Faker, base, en } from '@faker-js/faker';
+
+const DEFAULT_FAKER_SEED = 424242;
+const DEFAULT_REFERENCE_DATE = '2026-01-01T00:00:00.000Z';
+
+export function createTestFaker(seed = DEFAULT_FAKER_SEED): Faker {
+  const faker = new Faker({ locale: [en, base] });
+  faker.seed(seed);
+  faker.setDefaultRefDate(DEFAULT_REFERENCE_DATE);
+  return faker;
+}
+
+export function deriveTestSeed(namespace: string, offset = 0): number {
+  let hash = DEFAULT_FAKER_SEED;
+
+  for (const character of namespace) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+  }
+
+  return (hash + offset) >>> 0;
+}

--- a/packages/magnetar-sdk/tests/factories/magnetar-factories.ts
+++ b/packages/magnetar-sdk/tests/factories/magnetar-factories.ts
@@ -1,0 +1,121 @@
+import type { ToolResult } from '../../src/interfaces.js';
+import type {
+  EnvironmentSnapshot,
+  Goal,
+  MagnetarEidolon,
+  MemoryItem,
+  Task,
+  ToolCall,
+} from '../../src/models.js';
+import { createTestFaker } from './faker.js';
+
+type FactoryFaker = ReturnType<typeof createTestFaker>;
+
+function withDefaults<T>(value: T, overrides?: Partial<T>): T {
+  return {
+    ...value,
+    ...overrides,
+  };
+}
+
+export function createGoal(overrides?: Partial<Goal>, faker = createTestFaker()): Goal {
+  return withDefaults(
+    {
+      id: faker.string.uuid(),
+      description: faker.company.catchPhrase(),
+      createdAt: faker.date.recent(),
+      status: faker.helpers.arrayElement(['pending', 'active', 'completed', 'failed'] as const),
+    },
+    overrides,
+  );
+}
+
+export function createTask(overrides?: Partial<Task>, faker = createTestFaker()): Task {
+  return withDefaults(
+    {
+      id: faker.string.uuid(),
+      description: faker.hacker.phrase(),
+      status: faker.helpers.arrayElement(['planned', 'in_progress', 'completed', 'failed'] as const),
+      result: faker.lorem.sentence(),
+    },
+    overrides,
+  );
+}
+
+export function createMemoryItem(overrides?: Partial<MemoryItem>, faker = createTestFaker()): MemoryItem {
+  return withDefaults(
+    {
+      id: faker.string.uuid(),
+      content: faker.lorem.paragraph(),
+      embeddingId: faker.string.alphanumeric(12),
+      timestamp: faker.date.recent(),
+      metadata: {
+        source: faker.helpers.arrayElement(['tool', 'reflection', 'user'] as const),
+        priority: faker.number.int({ min: 1, max: 5 }),
+      },
+    },
+    overrides,
+  );
+}
+
+export function createToolCall(overrides?: Partial<ToolCall>, faker = createTestFaker()): ToolCall {
+  return withDefaults(
+    {
+      toolName: faker.helpers.arrayElement(['search', 'write_file', 'list_dir', 'run_command'] as const),
+      arguments: {
+        query: faker.lorem.words(3),
+        limit: faker.number.int({ min: 1, max: 10 }),
+      },
+      result: faker.lorem.sentence(),
+      error: undefined,
+      timestamp: faker.date.recent(),
+    },
+    overrides,
+  );
+}
+
+export function createEnvironmentSnapshot(
+  overrides?: Partial<EnvironmentSnapshot>,
+  faker = createTestFaker(),
+): EnvironmentSnapshot {
+  return withDefaults(
+    {
+      os: faker.helpers.arrayElement(['linux', 'macos', 'windows', 'web'] as const),
+      currentDirectory: faker.system.directoryPath(),
+      timestamp: faker.date.recent(),
+    },
+    overrides,
+  );
+}
+
+export function createMagnetarState(
+  overrides?: Partial<MagnetarEidolon>,
+  faker = createTestFaker(),
+): MagnetarEidolon {
+  return withDefaults(
+    {
+      agentId: faker.string.uuid(),
+      goal: createGoal(undefined, faker),
+      plan: Array.from({ length: 2 }, () => createTask(undefined, faker)),
+      shortTermMemory: Array.from({ length: 2 }, () => createMemoryItem(undefined, faker)),
+      toolHistory: Array.from({ length: 2 }, () => createToolCall(undefined, faker)),
+      environment: createEnvironmentSnapshot(undefined, faker),
+      metadata: {
+        runLabel: faker.word.words(2),
+        createdBy: 'faker-factory',
+      },
+    },
+    overrides,
+  );
+}
+
+export function createToolResult(overrides?: Partial<ToolResult>, faker = createTestFaker()): ToolResult {
+  return withDefaults(
+    {
+      success: true,
+      output: faker.lorem.sentence(),
+      error: undefined,
+    },
+    overrides,
+  );
+}


### PR DESCRIPTION
## Summary
- add deterministic Faker support to packages/magnetar-sdk
- add shared runtime test factories and reproducibility coverage
- adopt the shared factories in active SDK behavior tests and document the workflow

## Details
This PR completes issue #70.

Implementation slices included:
- 60803a9 test: add deterministic faker sdk factories
- b45bb6f test: adopt faker factories in agent specs
- 83b2609 docs: document faker factory workflow

What changed:
- added @faker-js/faker to the SDK test workspace
- added deterministic helpers in packages/magnetar-sdk/tests/factories/faker.ts
- added reusable model factories in packages/magnetar-sdk/tests/factories/magnetar-factories.ts
- added reproducibility coverage in packages/magnetar-sdk/tests/factories.spec.ts
- migrated packages/magnetar-sdk/tests/agent.spec.ts to the shared generated fixtures
- documented factory location, seed usage, and readability rules in TESTING.md

## Validation
- npm --prefix packages/magnetar-sdk test
- npm --prefix packages/magnetar-sdk run typecheck
- npm --prefix . run validate:required-docs

## Outcome
- closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added deterministic test fixture management and factory utilities for reproducible test scenarios.
* **Documentation**
  * Updated testing guidelines with concrete rules for test fixture management and seeding approaches.
* **Chores**
  * Added test dependency for fixture generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->